### PR TITLE
Add optional SHA-256 self-integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <algorithm>
 
+#include "SHA256.cpp"
+
 static const char* kTag = "[Javelin AntiCheat] ";
 
 // --- Configurable lists ---
@@ -102,7 +104,7 @@ static bool checkSuspiciousProcesses() {
     return false;
 }
 
-static bool checkSelfIntegrity(uint32_t expectedCrc) {
+static bool checkSelfIntegrityCrc32(uint32_t expectedCrc) {
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -113,9 +115,25 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     return current == expectedCrc;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
+static bool checkSelfIntegritySha256(const std::array<uint8_t, 32>& expected) {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    const auto current = sha256::hashBytes(bytes);
+    return current == expected;
+}
+
+// --- Entry helper ---
+// Embed a baseline checksum/hash once you ship a build.
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u  // Set at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#endif
+
+#ifndef JAVELIN_EXPECTED_SHA256_HEX
+#define JAVELIN_EXPECTED_SHA256_HEX nullptr  // Set at build time (64 hex chars)
 #endif
 
 int main() {
@@ -131,10 +149,20 @@ int main() {
         return 0xBAD; // code for bad process
     }
 
-    if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
+    if (JAVELIN_EXPECTED_SHA256_HEX != nullptr) {
+        std::array<uint8_t, 32> expected{};
+        if (!sha256::parseHex32(JAVELIN_EXPECTED_SHA256_HEX, expected)) {
+            std::cerr << kTag << "Integrity config invalid (expected SHA-256 must be 64 hex chars). Exiting.\n";
+            return 0xBADC0DE;
+        }
+        if (!checkSelfIntegritySha256(expected)) {
+            std::cerr << kTag << "Integrity check failed (SHA-256 mismatch). Exiting.\n";
+            return 0xC0FFEE;
+        }
+    } else if (JAVELIN_EXPECTED_CRC32 != 0u) {
+        if (!checkSelfIntegrityCrc32(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return 0xC0DE;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # py-workedtask
+
+## Integrity verification
+
+This repo includes optional self-integrity checks to detect basic tampering.
+
+### C++ (Windows) executable integrity (SHA-256)
+
+Build with `JAVELIN_EXPECTED_SHA256_HEX` set to the expected SHA-256 of the shipped `.exe`.
+
+- The value must be exactly 64 hex characters.
+- If the runtime hash doesn't match, the program exits early.
+
+Example (MSVC):
+
+```bat
+cl /EHsc AntiCheat.cpp /DJAVELIN_EXPECTED_SHA256_HEX="\"<64-hex-sha256>\""
+```
+
+To compute the hash for a built executable (PowerShell):
+
+```powershell
+Get-FileHash .\AntiCheat.exe -Algorithm SHA256
+```
+
+### C++ (Windows) executable integrity (CRC32)
+
+CRC32 is kept as a lightweight alternative:
+
+```bat
+cl /EHsc AntiCheat.cpp /DJAVELIN_EXPECTED_CRC32=0x12345678
+```

--- a/SHA256.cpp
+++ b/SHA256.cpp
@@ -1,0 +1,157 @@
+// SHA256.cpp
+// Minimal SHA-256 implementation (public domain style)
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace sha256 {
+
+static inline uint32_t rotr(uint32_t x, uint32_t n) {
+  return (x >> n) | (x << (32 - n));
+}
+
+static inline uint32_t ch(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (~x & z);
+}
+
+static inline uint32_t maj(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+static inline uint32_t big_sigma0(uint32_t x) {
+  return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22);
+}
+
+static inline uint32_t big_sigma1(uint32_t x) {
+  return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25);
+}
+
+static inline uint32_t small_sigma0(uint32_t x) {
+  return rotr(x, 7) ^ rotr(x, 18) ^ (x >> 3);
+}
+
+static inline uint32_t small_sigma1(uint32_t x) {
+  return rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10);
+}
+
+static constexpr uint32_t k[64] = {
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u, 0x3956c25bu,
+    0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u, 0xd807aa98u, 0x12835b01u,
+    0x243185beu, 0x550c7dc3u, 0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u,
+    0xc19bf174u, 0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+    0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau, 0x983e5152u,
+    0xa831c66du, 0xb00327c8u, 0xbf597fc7u, 0xc6e00bf3u, 0xd5a79147u,
+    0x06ca6351u, 0x14292967u, 0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu,
+    0x53380d13u, 0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+    0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u, 0xd192e819u,
+    0xd6990624u, 0xf40e3585u, 0x106aa070u, 0x19a4c116u, 0x1e376c08u,
+    0x2748774cu, 0x34b0bcb5u, 0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu,
+    0x682e6ff3u, 0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+    0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u,
+};
+
+static inline void store_be32(uint8_t* out, uint32_t x) {
+  out[0] = static_cast<uint8_t>(x >> 24);
+  out[1] = static_cast<uint8_t>(x >> 16);
+  out[2] = static_cast<uint8_t>(x >> 8);
+  out[3] = static_cast<uint8_t>(x);
+}
+
+static inline uint32_t load_be32(const uint8_t* in) {
+  return (static_cast<uint32_t>(in[0]) << 24) |
+         (static_cast<uint32_t>(in[1]) << 16) |
+         (static_cast<uint32_t>(in[2]) << 8) |
+         (static_cast<uint32_t>(in[3]));
+}
+
+static std::array<uint8_t, 32> digest(const uint8_t* data, size_t len) {
+  uint32_t h[8] = {
+      0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+      0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+  };
+
+  std::vector<uint8_t> msg(data, data + len);
+  const uint64_t bit_len = static_cast<uint64_t>(len) * 8u;
+
+  msg.push_back(0x80u);
+  while ((msg.size() % 64) != 56) msg.push_back(0x00u);
+
+  for (int i = 7; i >= 0; --i) {
+    msg.push_back(static_cast<uint8_t>((bit_len >> (i * 8)) & 0xffu));
+  }
+
+  uint32_t w[64];
+
+  for (size_t off = 0; off < msg.size(); off += 64) {
+    const uint8_t* chunk = msg.data() + off;
+
+    for (int i = 0; i < 16; ++i) w[i] = load_be32(chunk + (i * 4));
+    for (int i = 16; i < 64; ++i) {
+      w[i] = small_sigma1(w[i - 2]) + w[i - 7] + small_sigma0(w[i - 15]) +
+             w[i - 16];
+    }
+
+    uint32_t a = h[0];
+    uint32_t b = h[1];
+    uint32_t c = h[2];
+    uint32_t d = h[3];
+    uint32_t e = h[4];
+    uint32_t f = h[5];
+    uint32_t g = h[6];
+    uint32_t hh = h[7];
+
+    for (int i = 0; i < 64; ++i) {
+      const uint32_t t1 = hh + big_sigma1(e) + ch(e, f, g) + k[i] + w[i];
+      const uint32_t t2 = big_sigma0(a) + maj(a, b, c);
+      hh = g;
+      g = f;
+      f = e;
+      e = d + t1;
+      d = c;
+      c = b;
+      b = a;
+      a = t1 + t2;
+    }
+
+    h[0] += a;
+    h[1] += b;
+    h[2] += c;
+    h[3] += d;
+    h[4] += e;
+    h[5] += f;
+    h[6] += g;
+    h[7] += hh;
+  }
+
+  std::array<uint8_t, 32> out{};
+  for (int i = 0; i < 8; ++i) store_be32(out.data() + i * 4, h[i]);
+  return out;
+}
+
+static inline int hexVal(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+  if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+  return -1;
+}
+
+bool parseHex32(const char* hex, std::array<uint8_t, 32>& out) {
+  if (!hex) return false;
+  if (std::strlen(hex) != 64) return false;
+  for (size_t i = 0; i < 32; ++i) {
+    const int hi = hexVal(hex[i * 2]);
+    const int lo = hexVal(hex[i * 2 + 1]);
+    if (hi < 0 || lo < 0) return false;
+    out[i] = static_cast<uint8_t>((hi << 4) | lo);
+  }
+  return true;
+}
+
+std::array<uint8_t, 32> hashBytes(const std::vector<uint8_t>& data) {
+  return digest(data.data(), data.size());
+}
+
+}  // namespace sha256


### PR DESCRIPTION
Fixes #4

/claim #4

What changed:
- Added optional SHA-256 integrity check for the running executable (Windows).
- Check is enabled by defining `JAVELIN_EXPECTED_SHA256_HEX` (64 hex chars) at build time.
- Kept existing CRC32 option as a lightweight alternative.

How to use:
- Build with: `/DJAVELIN_EXPECTED_SHA256_HEX=""<64-hex>""`
- Compute hash with PowerShell: `Get-FileHash .\AntiCheat.exe -Algorithm SHA256`

Notes:
- This is best-effort tamper detection and not a full anti-cheat.
