### PR TITLE
feat: add optional SHA-256 integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,6 +1,6 @@
 // AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, self-integrity (SHA-256 or CRC32)
 
 #include <windows.h>
 #include <tlhelp32.h>
@@ -9,6 +9,13 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <sstream>
+#include <iomanip>
+
+// Optional: prefer SHA-256 integrity (available on Windows via BCrypt).
+// Define JAVELIN_EXPECTED_SHA256_HEX at build time to enable.
+#include <bcrypt.h>
+#pragma comment(lib, "bcrypt")
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -28,6 +35,62 @@ static std::vector<std::string> kSuspiciousProcesses = {
 static std::string toLower(std::string s) {
     std::transform(s.begin(), s.end(), s.begin(), ::tolower);
     return s;
+}
+
+static std::string bytesToHexLower(const uint8_t* data, size_t len) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (size_t i = 0; i < len; ++i) {
+        oss << std::setw(2) << static_cast<unsigned int>(data[i]);
+    }
+    return oss.str();
+}
+
+static std::string sha256Hex(const std::vector<uint8_t>& data) {
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+
+    if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0) {
+        return {};
+    }
+
+    DWORD hashObjectSize = 0;
+    DWORD cbData = 0;
+    if (BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, reinterpret_cast<PUCHAR>(&hashObjectSize), sizeof(hashObjectSize), &cbData, 0) != 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return {};
+    }
+
+    DWORD hashLen = 0;
+    if (BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH, reinterpret_cast<PUCHAR>(&hashLen), sizeof(hashLen), &cbData, 0) != 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return {};
+    }
+
+    std::vector<uint8_t> hashObject(hashObjectSize);
+    std::vector<uint8_t> hash(hashLen);
+
+    if (BCryptCreateHash(hAlg, &hHash, hashObject.data(), static_cast<ULONG>(hashObject.size()), nullptr, 0, 0) != 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return {};
+    }
+
+    if (BCryptHashData(hHash, const_cast<PUCHAR>(reinterpret_cast<const PUCHAR>(data.data())), static_cast<ULONG>(data.size()), 0) != 0) {
+        BCryptDestroyHash(hHash);
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return {};
+    }
+
+    if (BCryptFinishHash(hHash, hash.data(), static_cast<ULONG>(hash.size()), 0) != 0) {
+        BCryptDestroyHash(hHash);
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return {};
+    }
+
+    BCryptDestroyHash(hHash);
+    BCryptCloseAlgorithmProvider(hAlg, 0);
+
+    return bytesToHexLower(hash.data(), hash.size());
 }
 
 // Simple CRC32 (polynomial 0xEDB88320)
@@ -102,7 +165,7 @@ static bool checkSuspiciousProcesses() {
     return false;
 }
 
-static bool checkSelfIntegrity(uint32_t expectedCrc) {
+static bool checkSelfIntegrityCrc32(uint32_t expectedCrc) {
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -113,7 +176,27 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     return current == expectedCrc;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
+static bool checkSelfIntegritySha256(const std::string& expectedHexLower) {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    std::string currentHex = sha256Hex(bytes);
+    if (currentHex.empty()) return false;
+
+    std::string expected = expectedHexLower;
+    std::transform(expected.begin(), expected.end(), expected.begin(), ::tolower);
+
+    return currentHex == expected;
+}
+
+// --- Entry helper (embed a baseline hash once you ship a build) ---
+#ifndef JAVELIN_EXPECTED_SHA256_HEX
+#define JAVELIN_EXPECTED_SHA256_HEX ""  // Set this at build time (e.g., /DJAVELIN_EXPECTED_SHA256_HEX=\"<64 hex>\")
+#endif
+
 #ifndef JAVELIN_EXPECTED_CRC32
 #define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
 #endif
@@ -131,10 +214,15 @@ int main() {
         return 0xBAD; // code for bad process
     }
 
-    if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+    if (std::string(JAVELIN_EXPECTED_SHA256_HEX).size() > 0) {
+        if (!checkSelfIntegritySha256(JAVELIN_EXPECTED_SHA256_HEX)) {
+            std::cerr << kTag << "Integrity check failed (SHA-256 mismatch). Exiting.\n";
+            return 2;
+        }
+    } else if (JAVELIN_EXPECTED_CRC32 != 0u) {
+        if (!checkSelfIntegrityCrc32(JAVELIN_EXPECTED_CRC32)) {
+            std::cerr << kTag << "Integrity check failed (CRC32 mismatch). Exiting.\n";
+            return 2;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # py-workedtask
+
+## Integrity Verification
+
+### C++ (AntiCheat.cpp)
+
+By default, integrity verification is disabled.
+
+Enable SHA-256 verification (preferred) by compiling with:
+
+- JAVELIN_EXPECTED_SHA256_HEX = SHA-256 hex digest (lower/upper ok) of the built executable
+
+Example (MSVC):
+
+- /DJAVELIN_EXPECTED_SHA256_HEX=\"0123...<64 hex>...abcd\"
+
+If you don't want SHA-256, you can use CRC32 instead:
+
+- /DJAVELIN_EXPECTED_CRC32=0x12345678
+
+On mismatch, the program exits with code 2.
+
+### Python (integrity_check.py)
+
+Set JAVELIN_EXPECTED_SHA256 to the SHA-256 hex digest of integrity_check.py.
+
+Example:
+
+- export JAVELIN_EXPECTED_SHA256=$(python3 -c "import hashlib;print(hashlib.sha256(open('integrity_check.py','rb').read()).hexdigest())")
+- python3 integrity_check.py
+
+On mismatch, the script exits with code 2.

--- a/integrity_check.py
+++ b/integrity_check.py
@@ -1,0 +1,36 @@
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    expected = os.environ.get("JAVELIN_EXPECTED_SHA256")
+    if not expected:
+        print("[Javelin AntiCheat] JAVELIN_EXPECTED_SHA256 not set; skipping integrity check")
+        return 0
+
+    expected = expected.strip().lower()
+    script_path = Path(__file__).resolve()
+    actual = sha256_file(script_path)
+
+    if actual != expected:
+        print("[Javelin AntiCheat] Integrity check failed (SHA-256 mismatch)")
+        print(f"expected={expected}")
+        print(f"actual  ={actual}")
+        return 2
+
+    print("[Javelin AntiCheat] Integrity check OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #4\n\nWhat I changed\n- C++: added optional SHA-256 self-integrity verification for the running executable (uses Windows BCrypt). Enabled by defining JAVELIN_EXPECTED_SHA256_HEX at build time.\n- Python: added integrity_check.py which verifies its own SHA-256 against JAVELIN_EXPECTED_SHA256 env var.\n- Docs: added quick setup instructions and expected exit code behavior.\n\nProof\n- Python: verified exit code 2 on mismatch and 0 on match locally.\n\n/claim #4