### PR TITLE
feat: add Python SHA-256 integrity check (fixes #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # py-workedtask
+
+Minimal reference implementation for Javelin's Python worked-task prototype.
+
+## Integrity verification (Python)
+
+This repo includes an optional integrity check that computes the SHA-256 of the
+running script and compares it to an expected value.
+
+- Env var: `JAVELIN_EXPECTED_SHA256`
+- Behavior:
+  - If unset/empty: check is skipped (exit 0)
+  - If set and mismatched: guarded exit with non-zero code
+
+### Get the expected hash
+
+```bash
+python -c "import hashlib, pathlib; p=pathlib.Path('integrity_check.py'); print(hashlib.sha256(p.read_bytes()).hexdigest())"
+```
+
+### Run
+
+```bash
+export JAVELIN_EXPECTED_SHA256=<64-hex-digest>
+python integrity_check.py
+```
+
+### Tests
+
+```bash
+pytest -q
+```

--- a/integrity_check.py
+++ b/integrity_check.py
@@ -1,0 +1,54 @@
+"""
+Javelin Integrity Check (Python)
+
+- Computes SHA-256 of the current script file (__file__) and compares to
+  the value in environment variable JAVELIN_EXPECTED_SHA256.
+- Exits with non-zero code on mismatch.
+
+Usage:
+  - Set env var JAVELIN_EXPECTED_SHA256 to the expected 64-hex digest.
+  - Run this script normally; it will guard-exit if tampered.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+TAG = "[Javelin Py Integrity] "
+
+EXIT_INTEGRITY_SHA = 0x05A6
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    expected = os.environ.get("JAVELIN_EXPECTED_SHA256", "").strip().lower()
+    if not expected:
+        print(TAG + "No expected SHA-256 set; skipping integrity check.")
+        return 0
+
+    script_path = Path(__file__).resolve()
+    try:
+        got = sha256_file(script_path)
+    except Exception as e:
+        print(TAG + f"Failed to read script: {e}")
+        return EXIT_INTEGRITY_SHA
+
+    if got.lower() != expected.lower():
+        print(TAG + "Integrity check failed (SHA-256 mismatch). Exiting.")
+        return EXIT_INTEGRITY_SHA
+
+    print(TAG + "Integrity OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_integrity_check.py
+++ b/test_integrity_check.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    e = os.environ.copy()
+    if env:
+        e.update(env)
+    return subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "integrity_check.py")],
+        text=True,
+        capture_output=True,
+        env=e,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    import hashlib
+
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def test_skips_when_env_not_set():
+    p = run({"JAVELIN_EXPECTED_SHA256": ""})
+    assert p.returncode == 0
+    assert "skipping integrity check" in (p.stdout + p.stderr).lower()
+
+
+def test_fails_on_mismatch():
+    p = run({"JAVELIN_EXPECTED_SHA256": "0" * 64})
+    assert p.returncode != 0
+    assert "mismatch" in (p.stdout + p.stderr).lower()
+
+
+def test_passes_on_match():
+    expected = sha256_file(Path(__file__).parent / "integrity_check.py")
+    p = run({"JAVELIN_EXPECTED_SHA256": expected})
+    assert p.returncode == 0
+    assert "integrity ok" in (p.stdout + p.stderr).lower()


### PR DESCRIPTION
Fixes #4

Implements an optional SHA-256 integrity guard for the Python implementation:
- Reads expected digest from `JAVELIN_EXPECTED_SHA256`
- If unset/empty, the check is skipped (no behavior change for existing users)
- If set and mismatched, exits with a guarded non-zero code

Includes basic pytest coverage and minimal docs.

Demo (per bounty guidelines):
- Set an incorrect digest: the script exits with a mismatch.
- Set the correct digest: the script prints "Integrity OK".

/claim #4