### PR TITLE
feat: add SHA-256 integrity verification for C++ and Python paths

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -4,11 +4,14 @@
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <bcrypt.h>
 #include <iostream>
 #include <fstream>
 #include <vector>
 #include <string>
 #include <algorithm>
+
+#pragma comment(lib, "bcrypt.lib")
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -52,6 +55,55 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
     f.seekg(0, std::ios::beg);
     out.resize(static_cast<size_t>(size));
     if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
+    return true;
+}
+
+static std::string bytesToHex(const std::vector<uint8_t>& bytes) {
+    static const char* kHex = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) {
+        out.push_back(kHex[(b >> 4) & 0x0F]);
+        out.push_back(kHex[b & 0x0F]);
+    }
+    return out;
+}
+
+static bool sha256(const std::vector<uint8_t>& data, std::string& outHex) {
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+    DWORD objectLength = 0;
+    DWORD hashLength = 0;
+    DWORD copied = 0;
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+
+    status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0);
+    if (status < 0) return false;
+
+    status = BCryptGetProperty(hAlg, BCRYPT_OBJECT_LENGTH, reinterpret_cast<PUCHAR>(&objectLength), sizeof(DWORD), &copied, 0);
+    if (status < 0 || objectLength == 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return false;
+    }
+
+    status = BCryptGetProperty(hAlg, BCRYPT_HASH_LENGTH, reinterpret_cast<PUCHAR>(&hashLength), sizeof(DWORD), &copied, 0);
+    if (status < 0 || hashLength == 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return false;
+    }
+
+    std::vector<UCHAR> hashObject(objectLength);
+    std::vector<UCHAR> digest(hashLength);
+
+    status = BCryptCreateHash(hAlg, &hHash, hashObject.data(), static_cast<ULONG>(hashObject.size()), nullptr, 0, 0);
+    if (status >= 0) status = BCryptHashData(hHash, const_cast<PUCHAR>(data.data()), static_cast<ULONG>(data.size()), 0);
+    if (status >= 0) status = BCryptFinishHash(hHash, digest.data(), static_cast<ULONG>(digest.size()), 0);
+
+    if (hHash) BCryptDestroyHash(hHash);
+    if (hAlg) BCryptCloseAlgorithmProvider(hAlg, 0);
+
+    if (status < 0) return false;
+    outHex = bytesToHex(digest);
     return true;
 }
 
@@ -113,9 +165,25 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     return current == expectedCrc;
 }
 
+static bool checkSelfIntegritySha256(const std::string& expectedSha256) {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    std::string currentSha;
+    if (!sha256(bytes, currentSha)) return false;
+    return toLower(currentSha) == toLower(expectedSha256);
+}
+
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
 #ifndef JAVELIN_EXPECTED_CRC32
 #define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#endif
+
+#ifndef JAVELIN_EXPECTED_SHA256
+#define JAVELIN_EXPECTED_SHA256 ""  // Optional build-time SHA-256 string in hex
 #endif
 
 int main() {
@@ -134,7 +202,15 @@ int main() {
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return 0x1CC;
+        }
+    }
+
+    const std::string expectedSha = JAVELIN_EXPECTED_SHA256;
+    if (!expectedSha.empty()) {
+        if (!checkSelfIntegritySha256(expectedSha)) {
+            std::cerr << kTag << "Integrity check failed (SHA-256 mismatch). Exiting.\n";
+            return 0x1D5;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # py-workedtask
+
+Minimal anti-cheat integrity guard examples for C++ and Python.
+
+## C++ executable integrity
+
+`AntiCheat.cpp` supports both CRC32 and SHA-256 checks for the running executable.
+
+- CRC32 build-time define: `JAVELIN_EXPECTED_CRC32`
+- SHA-256 build-time define: `JAVELIN_EXPECTED_SHA256`
+
+Example (MSVC):
+
+```powershell
+cl /EHsc AntiCheat.cpp /DJAVELIN_EXPECTED_CRC32=0x12345678 /DJAVELIN_EXPECTED_SHA256=\"aabbcc...\" bcrypt.lib
+```
+
+If an expected value is provided and does not match the current executable, the program exits with a non-zero code.
+
+## Python script integrity
+
+`anti_cheat.py` computes SHA-256 for the script file and compares it with `JAVELIN_EXPECTED_SHA256`.
+
+Set expected hash:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = \"<64-char-lowercase-hex>\"
+```
+
+Compute hash:
+
+```powershell
+python -c \"import hashlib;print(hashlib.sha256(open('anti_cheat.py','rb').read()).hexdigest())\"
+```
+
+Run guarded script:
+
+```powershell
+python anti_cheat.py
+```
+
+If the hash mismatches, it exits immediately with a non-zero code.
+
+## Tests
+
+Run Python tests:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py'
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,45 @@
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+INTEGRITY_ERROR_CODE = 33
+
+
+def compute_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_script_integrity(expected_sha256: str, script_path: Path) -> bool:
+    expected = (expected_sha256 or "").strip().lower()
+    if not expected:
+        return True
+    if len(expected) != 64:
+        return False
+    current = compute_sha256(script_path).lower()
+    return current == expected
+
+
+def run_guarded(script_path: Path | None = None) -> int:
+    path = (script_path or Path(__file__)).resolve()
+    expected = os.getenv("JAVELIN_EXPECTED_SHA256", "")
+    if not verify_script_integrity(expected, path):
+        print(
+            "[Javelin AntiCheat] Integrity check failed (SHA-256 mismatch). Exiting.",
+            file=sys.stderr,
+        )
+        raise SystemExit(INTEGRITY_ERROR_CODE)
+    print("[Javelin AntiCheat] Integrity check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_guarded(Path(sys.argv[0])))

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,69 @@
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import anti_cheat
+
+
+class IntegrityTests(unittest.TestCase):
+    def test_compute_sha256_matches_hashlib(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "sample.txt"
+            path.write_text("javelin-integrity", encoding="utf-8")
+            expected = hashlib.sha256(path.read_bytes()).hexdigest()
+            self.assertEqual(anti_cheat.compute_sha256(path), expected)
+
+    def test_verify_script_integrity_passes_with_matching_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('ok')\n", encoding="utf-8")
+            expected = hashlib.sha256(path.read_bytes()).hexdigest()
+            self.assertTrue(anti_cheat.verify_script_integrity(expected, path))
+
+    def test_verify_script_integrity_fails_with_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('safe')\n", encoding="utf-8")
+            self.assertFalse(anti_cheat.verify_script_integrity("0" * 64, path))
+
+    def test_verify_script_integrity_fails_with_invalid_hash_length(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('safe')\n", encoding="utf-8")
+            self.assertFalse(anti_cheat.verify_script_integrity("abc", path))
+
+    def test_verify_script_integrity_ignores_missing_expected_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('safe')\n", encoding="utf-8")
+            self.assertTrue(anti_cheat.verify_script_integrity("", path))
+
+    def test_tampered_file_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('v1')\n", encoding="utf-8")
+            baseline = hashlib.sha256(path.read_bytes()).hexdigest()
+            path.write_text("print('v2')\n", encoding="utf-8")
+            self.assertFalse(anti_cheat.verify_script_integrity(baseline, path))
+
+    def test_guarded_exit_non_zero_on_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "script.py"
+            path.write_text("print('safe')\n", encoding="utf-8")
+            old = os.environ.get("JAVELIN_EXPECTED_SHA256")
+            os.environ["JAVELIN_EXPECTED_SHA256"] = "f" * 64
+            try:
+                with self.assertRaises(SystemExit) as exc:
+                    anti_cheat.run_guarded(path)
+                self.assertNotEqual(exc.exception.code, 0)
+            finally:
+                if old is None:
+                    os.environ.pop("JAVELIN_EXPECTED_SHA256", None)
+                else:
+                    os.environ["JAVELIN_EXPECTED_SHA256"] = old
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #4

This implements integrity verification for both paths described in #4.

What changed:
- C++ (`AntiCheat.cpp`)
  - kept optional CRC32 self-check (`JAVELIN_EXPECTED_CRC32`)
  - added optional SHA-256 self-check for running executable (`JAVELIN_EXPECTED_SHA256`)
  - guarded non-zero exits on mismatch for CRC and SHA checks
- Python (`anti_cheat.py`)
  - added SHA-256 script verification against `JAVELIN_EXPECTED_SHA256`
  - fail-closed guarded exit on mismatch
- Docs (`README.md`)
  - added setup instructions for expected hash values and usage for both implementations
- Tests (`tests/test_integrity.py`)
  - matching hash pass
  - mismatch fail
  - missing hash bypass
  - invalid hash format fail
  - tampered file detection
  - guarded non-zero exit on mismatch

Validation run:
- `python3 -m unittest discover -s tests -p "test_*.py"`
- `python3 -m py_compile anti_cheat.py`

Note:
- C++ source was updated in a Windows-compatible way (`bcrypt` API), but C++ runtime validation was not executed in this macOS environment.