### PR TITLE
feat: add SHA-256 integrity verification for C++ and Python (#4)

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,14 +1,17 @@
 // AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32 + SHA-256)
 
 #include <windows.h>
+#include <bcrypt.h>
 #include <tlhelp32.h>
 #include <iostream>
 #include <fstream>
 #include <vector>
 #include <string>
 #include <algorithm>
+
+#pragma comment(lib, "bcrypt.lib")
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -53,6 +56,47 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
     out.resize(static_cast<size_t>(size));
     if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
     return true;
+}
+
+// Convert a byte array to a lowercase hex string
+static std::string bytesToHex(const uint8_t* data, size_t len) {
+    static const char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        result.push_back(hex[data[i] >> 4]);
+        result.push_back(hex[data[i] & 0x0F]);
+    }
+    return result;
+}
+
+// Compute SHA-256 of a byte buffer using Windows BCrypt API
+static bool computeSHA256(const std::vector<uint8_t>& data, uint8_t hashOut[32]) {
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+    bool ok = false;
+
+    if (BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
+        return false;
+
+    if (BCryptCreateHash(hAlg, &hHash, nullptr, 0, nullptr, 0, 0) != 0) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return false;
+    }
+
+    if (BCryptHashData(hHash, const_cast<PUCHAR>(data.data()),
+                       static_cast<ULONG>(data.size()), 0) != 0) {
+        BCryptDestroyHash(hHash);
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+        return false;
+    }
+
+    if (BCryptFinishHash(hHash, hashOut, 32, 0) == 0)
+        ok = true;
+
+    BCryptDestroyHash(hHash);
+    BCryptCloseAlgorithmProvider(hAlg, 0);
+    return ok;
 }
 
 // --- Checks ---
@@ -113,9 +157,28 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     return current == expectedCrc;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
+// SHA-256 self-integrity check
+static bool checkSelfIntegritySHA256(const std::string& expectedHex) {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    uint8_t hash[32]{};
+    if (!computeSHA256(bytes, hash)) return false;
+
+    std::string currentHex = bytesToHex(hash, 32);
+    return currentHex == toLower(std::string(expectedHex));
+}
+
+// --- Build-time constants ---
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u  // Set at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#endif
+
+#ifndef JAVELIN_EXPECTED_SHA256
+#define JAVELIN_EXPECTED_SHA256 ""  // Set at build time (e.g., /DJAVELIN_EXPECTED_SHA256="abcdef...")
 #endif
 
 int main() {
@@ -131,10 +194,20 @@ int main() {
         return 0xBAD; // code for bad process
     }
 
+    // CRC32 integrity check
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            std::cerr << kTag << "Integrity check failed (CRC32 mismatch). Exiting.\n";
+            return 0xCRC;
+        }
+    }
+
+    // SHA-256 integrity check
+    static const std::string expectedSHA256 = JAVELIN_EXPECTED_SHA256;
+    if (!expectedSHA256.empty()) {
+        if (!checkSelfIntegritySHA256(expectedSHA256)) {
+            std::cerr << kTag << "Integrity check failed (SHA-256 mismatch). Exiting.\n";
+            return 0x54A; // SHA-256 mismatch exit code
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
 # py-workedtask
+
+Javelin Project — Minimal anti-cheat guards with self-integrity verification.
+
+## Features
+
+- **Debugger detection** — `IsDebuggerPresent` (Windows API / `sys.gettrace()` in Python)
+- **Suspicious process scanning** — detects cheat engines, debuggers, and reverse-engineering tools
+- **CRC32 self-integrity check** (C++ only) — fast tamper detection
+- **SHA-256 self-integrity check** (C++ and Python) — cryptographic tamper detection
+
+## C++ (`AntiCheat.cpp`)
+
+### Build
+
+Requires MSVC (Windows SDK). The BCrypt library is linked automatically via `#pragma comment`.
+
+```bash
+cl /EHsc AntiCheat.cpp
+```
+
+### SHA-256 Integrity Verification
+
+The SHA-256 check is **opt-in**. By default, `JAVELIN_EXPECTED_SHA256` is empty and the check is skipped.
+
+#### Step 1: Build without the hash
+
+```bash
+cl /EHsc AntiCheat.cpp /Fe:AntiCheat.exe
+```
+
+#### Step 2: Compute the SHA-256 of the built binary
+
+```powershell
+(Get-FileHash AntiCheat.exe -Algorithm SHA256).Hash.ToLower()
+```
+
+Or using `certutil`:
+
+```bash
+certutil -hashfile AntiCheat.exe SHA256
+```
+
+#### Step 3: Rebuild with the hash embedded
+
+```bash
+cl /EHsc /DJAVELIN_EXPECTED_SHA256="abc123..." AntiCheat.cpp /Fe:AntiCheat.exe
+```
+
+> **Note:** Since embedding the hash changes the binary, you must use a two-pass build or patch the hash into a data section post-build.
+
+#### CRC32 (existing)
+
+```bash
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `0xDEB` | Debugger detected |
+| `0xBAD` | Suspicious process detected |
+| `0xCRC` | CRC32 integrity mismatch |
+| `0x5HA` | SHA-256 integrity mismatch |
+
+## Python (`anti_cheat.py`)
+
+### Usage
+
+Run directly:
+
+```bash
+python anti_cheat.py
+```
+
+Or import in your project:
+
+```python
+from anti_cheat import verify_integrity, detect_suspicious_processes, is_debugger_present
+
+# Check integrity of a specific file
+if not verify_integrity("game.py"):
+    print("Tampered!")
+
+# Check for cheat tools
+if detect_suspicious_processes():
+    print("Cheat tool found!")
+```
+
+### SHA-256 Integrity Verification
+
+The SHA-256 check uses the `JAVELIN_EXPECTED_SHA256` environment variable.
+
+#### Step 1: Compute the hash of your script
+
+```bash
+python -c "import hashlib; print(hashlib.sha256(open('anti_cheat.py','rb').read()).hexdigest())"
+```
+
+Or on Linux/macOS:
+
+```bash
+sha256sum anti_cheat.py
+```
+
+Or on PowerShell:
+
+```powershell
+(Get-FileHash anti_cheat.py -Algorithm SHA256).Hash.ToLower()
+```
+
+#### Step 2: Set the environment variable and run
+
+**PowerShell:**
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "abc123..."
+python anti_cheat.py
+```
+
+**Bash:**
+
+```bash
+JAVELIN_EXPECTED_SHA256="abc123..." python anti_cheat.py
+```
+
+If the variable is not set, the integrity check is skipped (opt-in behavior).
+
+### API Reference
+
+| Function | Description |
+|----------|-------------|
+| `verify_integrity(filepath, expected_hash)` | Verify SHA-256 of a file. Defaults to self-check using env var. |
+| `compute_sha256(filepath)` | Return hex digest of a file's SHA-256 hash. |
+| `detect_suspicious_processes()` | Returns `True` if cheat/debug tools are running. |
+| `is_debugger_present()` | Returns `True` if a debugger is attached. |
+
+## License
+
+See [LICENSE](LICENSE).

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,125 @@
+"""
+anti_cheat.py
+Javelin Project - Anti-Cheat guards (Python edition)
+Features: SHA-256 self-integrity verification, suspicious process detection, debugger check
+"""
+
+import hashlib
+import os
+import sys
+
+
+# --- Suspicious process list (mirrors C++ version) ---
+SUSPICIOUS_PROCESSES = [
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+]
+
+
+def detect_suspicious_processes():
+    """Check for known cheat/debug tools in the process list.
+
+    Returns True if a suspicious process is found, False otherwise.
+    On non-Windows or if the check cannot run, returns False.
+    """
+    try:
+        import subprocess
+        output = subprocess.check_output("tasklist", shell=True, text=True).lower()
+        for proc in SUSPICIOUS_PROCESSES:
+            if proc.lower() in output:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def is_debugger_present():
+    """Best-effort debugger detection.
+
+    Returns True if a debugger is likely attached, False otherwise.
+    """
+    # Check the sys.gettrace() hook (set by debuggers like pdb, pydevd)
+    if sys.gettrace() is not None:
+        return True
+
+    # On Windows, check via ctypes IsDebuggerPresent
+    try:
+        import ctypes
+        if ctypes.windll.kernel32.IsDebuggerPresent():
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def compute_sha256(filepath):
+    """Compute the SHA-256 hex digest of a file.
+
+    Args:
+        filepath: Path to the file to hash.
+
+    Returns:
+        Lowercase hex string of the SHA-256 hash.
+    """
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_integrity(filepath=None, expected_hash=None):
+    """Verify SHA-256 integrity of a file.
+
+    Args:
+        filepath: Path to verify. Defaults to this script (__file__).
+        expected_hash: Expected SHA-256 hex string. Defaults to the
+                       JAVELIN_EXPECTED_SHA256 environment variable.
+
+    Returns:
+        True if verification passed or was skipped (no expected hash set).
+        False if the hash does not match.
+    """
+    if filepath is None:
+        filepath = os.path.abspath(__file__)
+
+    if expected_hash is None:
+        expected_hash = os.environ.get("JAVELIN_EXPECTED_SHA256", "")
+
+    if not expected_hash:
+        return True  # No expected hash configured; skip check
+
+    actual = compute_sha256(filepath)
+    return actual == expected_hash.lower()
+
+
+def main():
+    """Run all anti-cheat checks."""
+    tag = "[Javelin AntiCheat] "
+
+    print(f"{tag}starting checks...")
+
+    if is_debugger_present():
+        print(f"{tag}Debugger detected. Exiting.", file=sys.stderr)
+        sys.exit(0xDEB)
+
+    if detect_suspicious_processes():
+        print(f"{tag}Suspicious process detected. Exiting.", file=sys.stderr)
+        sys.exit(0xBAD)
+
+    if not verify_integrity():
+        print(f"{tag}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"{tag}All clear. Continue.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Implements optional SHA-256 integrity verification for both C++ and Python implementations, as requested in #4.

/claim #4

## Changes

### C++ (`AntiCheat.cpp`)
- Added SHA-256 computation using Windows-native `bcrypt.h` (BCryptHashData) — no external dependencies
- Added `JAVELIN_EXPECTED_SHA256` build-time constant (defaults to `""` = disabled)
- Added `checkSelfIntegritySHA256()` function that reads the running executable, computes SHA-256, and compares to expected hex
- Called in `main()` after existing CRC32 check — exits with `0x54A` on mismatch
- Existing CRC32 check left intact

### Python (`anti_cheat.py`) — new file
- `compute_sha256(filepath)` — returns hex digest using `hashlib`
- `verify_integrity()` — checks SHA-256 against `JAVELIN_EXPECTED_SHA256` env var
- Skips verification when env var is not set (optional verification)
- Exits with code 1 on mismatch
- Also includes basic anti-cheat functions (detect_suspicious_processes, is_debugger_present)

### Documentation (`README.md`)
- Full setup instructions for both C++ and Python SHA-256 verification
- How to compute expected hash values (PowerShell, bash, Python methods)
- Exit code reference table
- API reference

## Acceptance Criteria
- [x] Non-matching hash results in guarded exit (both C++ and Python)
- [x] Document how to set the expected values

fixes #4