### PR TITLE
feat: add Python anti-cheat monitor and baseline regression tests

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -4,6 +4,7 @@
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <intrin.h>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,6 +12,9 @@
 #include <algorithm>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static const int kExitDebuggerDetected = 0xDEB;
+static const int kExitSuspiciousProcess = 0xBAD;
+static const int kExitIntegrityFailure = 0xC3C;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -123,18 +127,18 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebuggerDetected;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrityFailure;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # py-workedtask
+
+Baseline anti-cheat protection for the Javelin project.
+
+Included implementations:
+
+- `AntiCheat.cpp`: Windows client checks for debugger attachment, suspicious processes, and optional CRC32 self-integrity.
+- `anti_cheat.py`: Python monitor with debugger detection and suspicious-process scanning.
+
+Run Python tests:
+
+```bash
+python3 -m unittest discover -s . -p "test_*.py" -v
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import ctypes
+import io
+import os
+import subprocess
+import sys
+from typing import Callable, Iterable, TextIO
+
+EXIT_OK = 0
+EXIT_DEBUGGER_DETECTED = 0xDEB
+EXIT_SUSPICIOUS_PROCESS = 0xBAD
+
+SUSPICIOUS_PROCESSES = {
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+}
+
+
+def is_debugger_present() -> bool:
+    if os.name != "nt":
+        return False
+
+    try:
+        return bool(ctypes.windll.kernel32.IsDebuggerPresent())
+    except (AttributeError, OSError):
+        return False
+
+
+def parse_tasklist_output(tasklist_output: str) -> list[str]:
+    reader = csv.reader(io.StringIO(tasklist_output))
+    names: list[str] = []
+    for row in reader:
+        if row:
+            names.append(row[0].strip().lower())
+    return names
+
+
+def list_process_names() -> list[str]:
+    if os.name != "nt":
+        return []
+
+    result = subprocess.run(
+        ["tasklist", "/FO", "CSV", "/NH"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return parse_tasklist_output(result.stdout)
+
+
+def has_suspicious_process(process_names: Iterable[str] | None = None) -> bool:
+    candidates = process_names if process_names is not None else list_process_names()
+    normalized = {name.strip().lower() for name in candidates}
+    return any(proc in normalized for proc in SUSPICIOUS_PROCESSES)
+
+
+def run_checks(
+    debugger_check: Callable[[], bool] | None = None,
+    process_check: Callable[[], bool] | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    debugger_check = debugger_check or is_debugger_present
+    process_check = process_check or has_suspicious_process
+    stderr = stderr or sys.stderr
+
+    if debugger_check():
+        print("[Javelin AntiCheat] Debugger detected. Exiting.", file=stderr)
+        return EXIT_DEBUGGER_DETECTED
+
+    if process_check():
+        print("[Javelin AntiCheat] Suspicious process detected. Exiting.", file=stderr)
+        return EXIT_SUSPICIOUS_PROCESS
+
+    print("[Javelin AntiCheat] All clear. Continue.", file=stderr)
+    return EXIT_OK
+
+
+def main() -> None:
+    sys.exit(run_checks())
+
+
+if __name__ == "__main__":
+    main()

--- a/test_anti_cheat.py
+++ b/test_anti_cheat.py
@@ -1,0 +1,48 @@
+import importlib
+import unittest
+
+
+class AntiCheatTests(unittest.TestCase):
+    def test_module_exists(self):
+        importlib.import_module("anti_cheat")
+
+    def test_debugger_detection_exits(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: True,
+            process_check=lambda: False,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_DEBUGGER_DETECTED)
+
+    def test_suspicious_process_detection_exits(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: False,
+            process_check=lambda: True,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_SUSPICIOUS_PROCESS)
+
+    def test_clean_environment_passes(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: False,
+            process_check=lambda: False,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_OK)
+
+    def test_tasklist_parser_normalizes_names(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        output = '"CheatEngine.exe","123","Console","1","10,000 K"\n"x64dbg.exe","456","Console","1","8,000 K"\n'
+        self.assertEqual(
+            anti_cheat.parse_tasklist_output(output),
+            ["cheatengine.exe", "x64dbg.exe"],
+        )
+
+    def test_suspicious_process_match_is_case_insensitive(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        self.assertTrue(anti_cheat.has_suspicious_process(["CheatEngine.exe"]))
+        self.assertFalse(anti_cheat.has_suspicious_process(["explorer.exe"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #2

## Summary
- add the missing `anti_cheat.py` monitor so issue #2 can satisfy the Python acceptance criteria
- add focused unit tests for debugger detection, suspicious-process detection, tasklist parsing, and guarded exit codes
- fix the native `AntiCheat.cpp` header / exit-code issue uncovered during review
- document the baseline anti-cheat flow and test command in the README

## Why this helps
The repository currently ships only the C++ sample, so the issue cannot fully pass its own acceptance criteria for the Python monitor path. This PR closes that gap with a small, dependency-light implementation.

## Verification
```bash
python3 -m unittest discover -s . -p "test_*.py" -v
python3 -m py_compile anti_cheat.py
```

## Notes
- Python path is fully verified in this environment.
- C++ runtime compilation was not executed here because this machine is macOS, but the native source fix is limited to missing intrinsics include + valid exit constants.
