### PR TITLE
feat: add SHA-256 integrity verification for Python anti-cheat path

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -4,6 +4,7 @@
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <intrin.h>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,6 +12,9 @@
 #include <algorithm>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static const int kExitDebuggerDetected = 0xDEB;
+static const int kExitSuspiciousProcess = 0xBAD;
+static const int kExitIntegrityFailure = 0xC3C;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -123,18 +127,18 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebuggerDetected;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrityFailure;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # py-workedtask
+
+Baseline anti-cheat protection for the Javelin project.
+
+Included implementations:
+
+- `AntiCheat.cpp`: Windows client checks for debugger attachment, suspicious processes, and optional CRC32 self-integrity.
+- `anti_cheat.py`: Python monitor with debugger detection and suspicious-process scanning.
+
+Run Python tests:
+
+```bash
+python3 -m unittest discover -s . -p "test_*.py" -v
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ Baseline anti-cheat protection for the Javelin project.
 Included implementations:
 
 - `AntiCheat.cpp`: Windows client checks for debugger attachment, suspicious processes, and optional CRC32 self-integrity.
-- `anti_cheat.py`: Python monitor with debugger detection and suspicious-process scanning.
+- `anti_cheat.py`: Python monitor with debugger detection, suspicious-process scanning, and optional SHA-256 integrity verification.
+
+Python integrity verification:
+
+- set `JAVELIN_EXPECTED_SHA256` to the expected script hash
+- when the environment variable is present and does not match the current script, the monitor exits with a guarded failure code
 
 Run Python tests:
 

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import ctypes
+import io
+import os
+import subprocess
+import sys
+from typing import Callable, Iterable, TextIO
+
+EXIT_OK = 0
+EXIT_DEBUGGER_DETECTED = 0xDEB
+EXIT_SUSPICIOUS_PROCESS = 0xBAD
+
+SUSPICIOUS_PROCESSES = {
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+}
+
+
+def is_debugger_present() -> bool:
+    if os.name != "nt":
+        return False
+
+    try:
+        return bool(ctypes.windll.kernel32.IsDebuggerPresent())
+    except (AttributeError, OSError):
+        return False
+
+
+def parse_tasklist_output(tasklist_output: str) -> list[str]:
+    reader = csv.reader(io.StringIO(tasklist_output))
+    names: list[str] = []
+    for row in reader:
+        if row:
+            names.append(row[0].strip().lower())
+    return names
+
+
+def list_process_names() -> list[str]:
+    if os.name != "nt":
+        return []
+
+    result = subprocess.run(
+        ["tasklist", "/FO", "CSV", "/NH"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return parse_tasklist_output(result.stdout)
+
+
+def has_suspicious_process(process_names: Iterable[str] | None = None) -> bool:
+    candidates = process_names if process_names is not None else list_process_names()
+    normalized = {name.strip().lower() for name in candidates}
+    return any(proc in normalized for proc in SUSPICIOUS_PROCESSES)
+
+
+def run_checks(
+    debugger_check: Callable[[], bool] | None = None,
+    process_check: Callable[[], bool] | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    debugger_check = debugger_check or is_debugger_present
+    process_check = process_check or has_suspicious_process
+    stderr = stderr or sys.stderr
+
+    if debugger_check():
+        print("[Javelin AntiCheat] Debugger detected. Exiting.", file=stderr)
+        return EXIT_DEBUGGER_DETECTED
+
+    if process_check():
+        print("[Javelin AntiCheat] Suspicious process detected. Exiting.", file=stderr)
+        return EXIT_SUSPICIOUS_PROCESS
+
+    print("[Javelin AntiCheat] All clear. Continue.", file=stderr)
+    return EXIT_OK
+
+
+def main() -> None:
+    sys.exit(run_checks())
+
+
+if __name__ == "__main__":
+    main()

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import ctypes
+import hashlib
 import io
 import os
 import subprocess
@@ -11,6 +12,7 @@ from typing import Callable, Iterable, TextIO
 EXIT_OK = 0
 EXIT_DEBUGGER_DETECTED = 0xDEB
 EXIT_SUSPICIOUS_PROCESS = 0xBAD
+EXIT_INTEGRITY_FAILURE = 0x54A
 
 SUSPICIOUS_PROCESSES = {
     "cheatengine.exe",
@@ -64,13 +66,30 @@ def has_suspicious_process(process_names: Iterable[str] | None = None) -> bool:
     return any(proc in normalized for proc in SUSPICIOUS_PROCESSES)
 
 
+def compute_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_integrity(path: str, expected_hash: str | None = None) -> bool:
+    expected_hash = expected_hash or os.environ.get("JAVELIN_EXPECTED_SHA256", "")
+    if not expected_hash:
+        return True
+    return compute_sha256(path).lower() == expected_hash.strip().lower()
+
+
 def run_checks(
     debugger_check: Callable[[], bool] | None = None,
     process_check: Callable[[], bool] | None = None,
+    integrity_check: Callable[[], bool] | None = None,
     stderr: TextIO | None = None,
 ) -> int:
     debugger_check = debugger_check or is_debugger_present
     process_check = process_check or has_suspicious_process
+    integrity_check = integrity_check or (lambda: verify_integrity(__file__))
     stderr = stderr or sys.stderr
 
     if debugger_check():
@@ -80,6 +99,10 @@ def run_checks(
     if process_check():
         print("[Javelin AntiCheat] Suspicious process detected. Exiting.", file=stderr)
         return EXIT_SUSPICIOUS_PROCESS
+
+    if not integrity_check():
+        print("[Javelin AntiCheat] Integrity check failed. Exiting.", file=stderr)
+        return EXIT_INTEGRITY_FAILURE
 
     print("[Javelin AntiCheat] All clear. Continue.", file=stderr)
     return EXIT_OK

--- a/test_anti_cheat.py
+++ b/test_anti_cheat.py
@@ -1,0 +1,48 @@
+import importlib
+import unittest
+
+
+class AntiCheatTests(unittest.TestCase):
+    def test_module_exists(self):
+        importlib.import_module("anti_cheat")
+
+    def test_debugger_detection_exits(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: True,
+            process_check=lambda: False,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_DEBUGGER_DETECTED)
+
+    def test_suspicious_process_detection_exits(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: False,
+            process_check=lambda: True,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_SUSPICIOUS_PROCESS)
+
+    def test_clean_environment_passes(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: False,
+            process_check=lambda: False,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_OK)
+
+    def test_tasklist_parser_normalizes_names(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        output = '"CheatEngine.exe","123","Console","1","10,000 K"\n"x64dbg.exe","456","Console","1","8,000 K"\n'
+        self.assertEqual(
+            anti_cheat.parse_tasklist_output(output),
+            ["cheatengine.exe", "x64dbg.exe"],
+        )
+
+    def test_suspicious_process_match_is_case_insensitive(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        self.assertTrue(anti_cheat.has_suspicious_process(["CheatEngine.exe"]))
+        self.assertFalse(anti_cheat.has_suspicious_process(["explorer.exe"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_anti_cheat.py
+++ b/test_anti_cheat.py
@@ -1,4 +1,7 @@
 import importlib
+import hashlib
+import os
+import tempfile
 import unittest
 
 
@@ -42,6 +45,46 @@ class AntiCheatTests(unittest.TestCase):
         anti_cheat = importlib.import_module("anti_cheat")
         self.assertTrue(anti_cheat.has_suspicious_process(["CheatEngine.exe"]))
         self.assertFalse(anti_cheat.has_suspicious_process(["explorer.exe"]))
+
+    def test_sha256_helper_matches_python_hashlib(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        with tempfile.NamedTemporaryFile("wb", delete=False) as handle:
+            handle.write(b"javelin")
+            path = handle.name
+        self.addCleanup(lambda: os.remove(path) if os.path.exists(path) else None)
+
+        self.assertEqual(
+            anti_cheat.compute_sha256(path),
+            hashlib.sha256(b"javelin").hexdigest(),
+        )
+
+    def test_integrity_check_passes_with_matching_hash(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        with tempfile.NamedTemporaryFile("wb", delete=False) as handle:
+            handle.write(b"trusted")
+            path = handle.name
+        self.addCleanup(lambda: os.remove(path) if os.path.exists(path) else None)
+
+        expected = hashlib.sha256(b"trusted").hexdigest()
+        self.assertTrue(anti_cheat.verify_integrity(path, expected))
+
+    def test_integrity_check_fails_with_mismatch(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        with tempfile.NamedTemporaryFile("wb", delete=False) as handle:
+            handle.write(b"trusted")
+            path = handle.name
+        self.addCleanup(lambda: os.remove(path) if os.path.exists(path) else None)
+
+        self.assertFalse(anti_cheat.verify_integrity(path, "0" * 64))
+
+    def test_run_checks_exits_on_integrity_failure(self):
+        anti_cheat = importlib.import_module("anti_cheat")
+        code = anti_cheat.run_checks(
+            debugger_check=lambda: False,
+            process_check=lambda: False,
+            integrity_check=lambda: False,
+        )
+        self.assertEqual(code, anti_cheat.EXIT_INTEGRITY_FAILURE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
/claim #4

## Summary
- add optional SHA-256 integrity verification to the Python monitor
- keep integrity enforcement opt-in via `JAVELIN_EXPECTED_SHA256` so normal dev runs stay unblocked
- add regression tests for matching hash, mismatch, helper correctness, and integrity-driven exit codes
- document how to configure the expected hash in the README

## Why this helps
Issue #4 asks for integrity verification on both runtimes. The Python side now has a dependency-light implementation that can be enabled in production while staying easy to test locally.

## Verification
```bash
python3 -m unittest discover -s . -p "test_*.py" -v
python3 -m py_compile anti_cheat.py
```

## Notes
- This branch builds on the Python monitor path already proposed for issue #2 so the repository has a consistent cross-runtime baseline.
- C++ runtime verification still needs Windows compilation for end-to-end validation; this PR focuses on the Python integrity path requested by issue #4.
