### PR TITLE
feat: add Python integrity verification with SHA-256

### DIFF
--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Javelin Project - Python Anti-Cheat: Integrity Verification
+Computes SHA-256 of this script and compares to JAVELIN_EXPECTED_SHA256 env var.
+"""
+
+import os
+import sys
+import hashlib
+
+TAG = "[Javelin AntiCheat] "
+
+
+def compute_file_sha256(filepath: str) -> str:
+    """Compute SHA-256 hash of a file."""
+    sha256 = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def check_integrity() -> bool:
+    """
+    Check script integrity by comparing SHA-256 to JAVELIN_EXPECTED_SHA256 env var.
+    Returns True if integrity check passes, False otherwise.
+    """
+    expected_sha256 = os.environ.get("JAVELIN_EXPECTED_SHA256", "").strip()
+    
+    if not expected_sha256:
+        # No expected hash set - skip check (same as C++ behavior with JAVELIN_EXPECTED_CRC32=0)
+        print(f"{TAG}JAVELIN_EXPECTED_SHA256 not set, skipping integrity check.")
+        return True
+    
+    # Get this script's path
+    script_path = os.path.abspath(__file__)
+    
+    if not os.path.exists(script_path):
+        print(f"{TAG}Error: Cannot find script file at {script_path}")
+        return False
+    
+    current_sha256 = compute_file_sha256(script_path)
+    
+    if current_sha256 == expected_sha256:
+        print(f"{TAG}Integrity check passed (SHA-256 match).")
+        return True
+    else:
+        print(f"{TAG}Integrity check FAILED!")
+        print(f"  Expected: {expected_sha256}")
+        print(f"  Current:  {current_sha256}")
+        return False
+
+
+def main():
+    print(f"{TAG}Starting Python integrity check...")
+    
+    if not check_integrity():
+        print(f"{TAG}Integrity violation detected. Exiting.")
+        sys.exit(1)
+    
+    print(f"{TAG}All clear. Continue.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implemented Python integrity verification for the Javelin Project.

### What was added

Created  with the following features:

1. **SHA-256 computation**: Computes hash of the running script file using Python's 

2. **Environment variable check**: Compares the computed hash against  env var

3. **Graceful handling**:
   - If  is not set → skips check (like C++ with )
   - If hash matches → passes, exits with code 0
   - If hash mismatch → fails, exits with code 1

### Usage

91cf6df8bee4b9590599bc3a7386d9547cf4edcdc0b3a99c577ba1b8394579fc
[Javelin AntiCheat] Starting Python integrity check...
[Javelin AntiCheat] Integrity check FAILED!
  Expected: your-hash-here
  Current:  91cf6df8bee4b9590599bc3a7386d9547cf4edcdc0b3a99c577ba1b8394579fc
[Javelin AntiCheat] Integrity violation detected. Exiting.

### Testing

- ✅ No env var → skips check, exit 0
- ✅ Wrong hash → fails, exit 1  
- ✅ Correct hash → passes, exit 0

Resolves issue #4