### PR TITLE
feat: add baseline Python anti-cheat monitor

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -2,17 +2,27 @@
 // Javelin Project - Minimal Anti-Cheat guards
 // Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
 
-#include <windows.h>
-#include <tlhelp32.h>
+#include <cstdint>
 #include <iostream>
+
+#ifdef _WIN32
+#include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <vector>
+#endif
+
 #include <string>
-#include <algorithm>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <tlhelp32.h>
+#endif
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
 // --- Configurable lists ---
+#ifdef _WIN32
 static std::vector<std::string> kSuspiciousProcesses = {
     "cheatengine.exe",
     "ollydbg.exe",
@@ -26,7 +36,9 @@ static std::vector<std::string> kSuspiciousProcesses = {
 
 // --- Utils ---
 static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
     return s;
 }
 
@@ -54,36 +66,30 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
     if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
     return true;
 }
+#endif
 
 // --- Checks ---
 static bool checkDebugger() {
+#ifdef _WIN32
     if (IsDebuggerPresent()) return true;
 
-    // Secondary anti-debug: CheckBeingDebugged flag in PEB (best-effort)
-#ifdef _M_IX86
-    // 32-bit: fs:[30h] -> PEB, offset 2 = BeingDebugged (BYTE)
-    __try {
-        BYTE* peb = *(BYTE**)_readfsdword(0x30);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#elif defined(_M_X64)
-    // 64-bit: gs:[60h] -> PEB
-    __try {
-        BYTE* peb = *(BYTE**)_readgsqword(0x60);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    BOOL remoteDebuggerPresent = FALSE;
+    if (CheckRemoteDebuggerPresent(GetCurrentProcess(), &remoteDebuggerPresent)) {
+        return remoteDebuggerPresent == TRUE;
+    }
 #endif
 
     return false;
 }
 
 static bool checkSuspiciousProcesses() {
+#ifdef _WIN32
     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snap == INVALID_HANDLE_VALUE) return false;
 
-    PROCESSENTRY32 pe{};
+    PROCESSENTRY32A pe{};
     pe.dwSize = sizeof(pe);
-    if (!Process32First(snap, &pe)) {
+    if (!Process32FirstA(snap, &pe)) {
         CloseHandle(snap);
         return false;
     }
@@ -96,13 +102,17 @@ static bool checkSuspiciousProcesses() {
                 return true;
             }
         }
-    } while (Process32Next(snap, &pe));
+    } while (Process32NextA(snap, &pe));
 
     CloseHandle(snap);
     return false;
+#else
+    return false;
+#endif
 }
 
 static bool checkSelfIntegrity(uint32_t expectedCrc) {
+#ifdef _WIN32
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -111,6 +121,10 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 
     uint32_t current = crc32(bytes);
     return current == expectedCrc;
+#else
+    (void)expectedCrc;
+    return false;
+#endif
 }
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
@@ -134,7 +148,7 @@ int main() {
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return 0xC0DE; // custom code (note: may be truncated by the shell)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # py-workedtask
+
+Baseline anti-cheat guards for the Javelin project.
+
+## C++ client
+
+`AntiCheat.cpp` checks for an attached debugger and a short list of suspicious
+Windows process names. It also supports an optional build-time CRC guard:
+
+```sh
+c++ -std=c++17 -Wall -Wextra -pedantic AntiCheat.cpp -o anticheat
+```
+
+On non-Windows systems the platform-specific checks are compiled as no-ops so
+the client remains buildable in CI.
+
+## Python monitor
+
+`anti_cheat.py` mirrors the baseline checks for the Python runtime path:
+
+```sh
+python3 anti_cheat.py
+python3 -m unittest discover -s tests
+```
+
+The monitor exits with a non-zero status when it detects an attached debugger
+or a known suspicious process.

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,115 @@
+"""Baseline anti-cheat monitor for the Python runtime path."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import PureWindowsPath
+from typing import Iterable, Optional, Sequence
+
+
+DEBUGGER_EXIT_CODE = 0xDE
+SUSPICIOUS_PROCESS_EXIT_CODE = 0xAD
+
+SUSPICIOUS_PROCESS_NAMES = frozenset(
+    {
+        "cheatengine.exe",
+        "ollydbg.exe",
+        "x64dbg.exe",
+        "httpdebuggerui.exe",
+        "ida.exe",
+        "ida64.exe",
+        "scylla.exe",
+        "processhacker.exe",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    ok: bool
+    reason: str
+    exit_code: int
+
+
+def normalize_process_name(process_name: str) -> str:
+    """Return a case-insensitive executable basename."""
+    stripped = process_name.strip().strip('"')
+    if "\\" in stripped:
+        stripped = PureWindowsPath(stripped).name
+    else:
+        stripped = os.path.basename(stripped)
+    return stripped.casefold()
+
+
+def is_debugger_attached() -> bool:
+    if sys.gettrace() is not None:
+        return True
+
+    if os.name != "nt":
+        return False
+
+    kernel32 = ctypes.windll.kernel32
+    if kernel32.IsDebuggerPresent():
+        return True
+
+    remote_debugger_present = ctypes.c_bool(False)
+    current_process = kernel32.GetCurrentProcess()
+    if kernel32.CheckRemoteDebuggerPresent(
+        current_process,
+        ctypes.byref(remote_debugger_present),
+    ):
+        return remote_debugger_present.value
+
+    return False
+
+
+def iter_process_names() -> list[str]:
+    if os.name == "nt":
+        command = ["tasklist", "/FO", "CSV", "/NH"]
+    else:
+        command = ["ps", "-axo", "comm="]
+
+    output = subprocess.check_output(command, text=True, stderr=subprocess.DEVNULL)
+    return [line.split(",", 1)[0].strip('"') for line in output.splitlines() if line.strip()]
+
+
+def has_suspicious_process(
+    process_names: Iterable[str],
+    suspicious_processes: Sequence[str] = tuple(SUSPICIOUS_PROCESS_NAMES),
+) -> bool:
+    suspicious = {normalize_process_name(name) for name in suspicious_processes}
+    return any(normalize_process_name(name) in suspicious for name in process_names)
+
+
+def run_checks(
+    process_names: Optional[Iterable[str]] = None,
+    debugger_attached: Optional[bool] = None,
+) -> CheckResult:
+    if debugger_attached is None:
+        debugger_attached = is_debugger_attached()
+
+    if debugger_attached:
+        return CheckResult(False, "Debugger detected", DEBUGGER_EXIT_CODE)
+
+    if process_names is None:
+        process_names = iter_process_names()
+
+    if has_suspicious_process(process_names):
+        return CheckResult(False, "Suspicious process detected", SUSPICIOUS_PROCESS_EXIT_CODE)
+
+    return CheckResult(True, "All clear", 0)
+
+
+def main() -> int:
+    result = run_checks()
+    stream = sys.stdout if result.ok else sys.stderr
+    print(f"[Javelin AntiCheat] {result.reason}", file=stream)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anti_cheat.py
+++ b/tests/test_anti_cheat.py
@@ -1,0 +1,53 @@
+import unittest
+
+from anti_cheat import (
+    DEBUGGER_EXIT_CODE,
+    SUSPICIOUS_PROCESS_EXIT_CODE,
+    has_suspicious_process,
+    normalize_process_name,
+    run_checks,
+)
+
+
+class AntiCheatTests(unittest.TestCase):
+    def test_normalize_process_name_handles_case_quotes_and_windows_paths(self):
+        self.assertEqual(
+            normalize_process_name('"C:\\Tools\\X64DBG.EXE"'),
+            "x64dbg.exe",
+        )
+
+    def test_suspicious_process_detection_matches_exact_basename(self):
+        self.assertTrue(
+            has_suspicious_process(
+                [
+                    "python.exe",
+                    "C:\\Tools\\CheatEngine.exe",
+                ],
+            ),
+        )
+        self.assertFalse(has_suspicious_process(["not-cheatengine.exe", "python.exe"]))
+
+    def test_debugger_detection_takes_priority(self):
+        result = run_checks(["cheatengine.exe"], debugger_attached=True)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "Debugger detected")
+        self.assertEqual(result.exit_code, DEBUGGER_EXIT_CODE)
+
+    def test_suspicious_process_result(self):
+        result = run_checks(["python.exe", "x64dbg.exe"], debugger_attached=False)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.reason, "Suspicious process detected")
+        self.assertEqual(result.exit_code, SUSPICIOUS_PROCESS_EXIT_CODE)
+
+    def test_clean_processes_pass(self):
+        result = run_checks(["python.exe", "explorer.exe"], debugger_attached=False)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.reason, "All clear")
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `anti_cheat.py` for the Python runtime path with debugger and suspicious-process checks
- add unit coverage for process-name normalization, debugger priority, suspicious process detection, and clean runs
- keep the C++ client buildable on non-Windows CI while preserving Windows debugger/process checks and fixing the invalid CRC exit literal

Fixes #2
/claim #2

## Tests
- `python3 -m py_compile anti_cheat.py tests/test_anti_cheat.py`
- `python3 -m unittest discover -s tests -v`
- `python3 anti_cheat.py`
- `c++ -std=c++17 -Wall -Wextra -pedantic AntiCheat.cpp -o /tmp/javelin-anticheat-check && /tmp/javelin-anticheat-check`
- `git diff --check`