### PR TITLE
Add optional integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -114,6 +114,7 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 }
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
+// Example MSVC: cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
 #ifndef JAVELIN_EXPECTED_CRC32
 #define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
 #endif
@@ -134,7 +135,7 @@ int main() {
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return 0xC7C; // integrity check failure
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat examples for C++ and Python.
+
+## Python integrity verification
+
+The Python guard can optionally verify that `anti_cheat.py` has not been
+tampered with. The check is disabled by default and becomes active when the
+`JAVELIN_EXPECTED_SHA256` environment variable is set.
+
+Generate the expected hash:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import hashlib
+print(hashlib.sha256(Path("anti_cheat.py").read_bytes()).hexdigest())
+PY
+```
+
+Run with the expected hash:
+
+```bash
+export JAVELIN_EXPECTED_SHA256=<sha256-from-command-above>
+python3 anti_cheat.py
+```
+
+If the file contents do not match the expected hash, the process exits with a
+guarded failure code and prints an integrity failure message.
+
+## C++ integrity verification
+
+`AntiCheat.cpp` supports an optional build-time CRC32 check of the running
+executable. Leave `JAVELIN_EXPECTED_CRC32` as `0` to disable the check while
+developing. Set it at compile time when shipping a known-good build.
+
+Example MSVC build flag:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+When the computed CRC32 of the running executable does not match the expected
+value, the guard exits before continuing.

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Minimal Python anti-cheat guard with optional script integrity verification.
+
+Set JAVELIN_EXPECTED_SHA256 to the expected SHA-256 digest of this script to
+enable tamper detection. If the variable is unset, the integrity check is
+skipped so development builds remain easy to run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+INTEGRITY_FAILURE_EXIT_CODE = 0xC7C
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def check_script_integrity(script_path: Path | None = None) -> bool:
+    expected = os.getenv(EXPECTED_SHA256_ENV)
+    if not expected:
+        return True
+
+    normalized_expected = expected.strip().lower()
+    if len(normalized_expected) != 64:
+        print(f"{TAG}{EXPECTED_SHA256_ENV} must be a 64-character SHA-256 hex digest.", file=sys.stderr)
+        return False
+
+    path = script_path or Path(__file__).resolve()
+    try:
+        current = sha256_file(path)
+    except OSError as exc:
+        print(f"{TAG}Unable to read script for integrity check: {exc}", file=sys.stderr)
+        return False
+
+    if current != normalized_expected:
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return False
+
+    return True
+
+
+def main() -> int:
+    print(f"{TAG}starting checks...")
+    if not check_script_integrity():
+        return INTEGRITY_FAILURE_EXIT_CODE
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_integrity.py
+++ b/test_integrity.py
@@ -1,0 +1,40 @@
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import anti_cheat
+
+
+class IntegrityVerificationTests(unittest.TestCase):
+    def test_missing_expected_hash_skips_check(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(anti_cheat.check_script_integrity(Path("does-not-need-to-exist")))
+
+    def test_matching_hash_passes(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b"trusted script")
+            path = Path(tmp.name)
+        try:
+            expected = hashlib.sha256(path.read_bytes()).hexdigest()
+            with patch.dict(os.environ, {anti_cheat.EXPECTED_SHA256_ENV: expected}, clear=True):
+                self.assertTrue(anti_cheat.check_script_integrity(path))
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_mismatched_hash_fails(self):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(b"tampered script")
+            path = Path(tmp.name)
+        try:
+            wrong_hash = "0" * 64
+            with patch.dict(os.environ, {anti_cheat.EXPECTED_SHA256_ENV: wrong_hash}, clear=True):
+                self.assertFalse(anti_cheat.check_script_integrity(path))
+        finally:
+            path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a Python anti-cheat guard with optional SHA-256 script integrity verification via `JAVELIN_EXPECTED_SHA256`.
- Documents how to generate/set expected Python SHA-256 hashes and how to configure the C++ build-time CRC32 value.
- Fixes the invalid C++ integrity failure return literal and keeps the existing CRC32 self-check flow guarded by `JAVELIN_EXPECTED_CRC32`.
- Adds Python unit tests for skipped, matching, and mismatched integrity checks.

## Verification
- `python3 -m unittest -v`

Fixes #4
