### PR TITLE
Add Python SHA-256 integrity guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # py-workedtask
+
+## Integrity verification
+
+### Python script guard
+
+`javelin_integrity.py` provides optional SHA-256 verification for Python
+entrypoints. When `JAVELIN_EXPECTED_SHA256` is set, the guard hashes the target
+script and exits if the digest does not match. When the variable is unset, the
+guard is disabled.
+
+Generate an expected hash:
+
+```bash
+python - <<'PY'
+from javelin_integrity import sha256_file
+print(sha256_file("your_game_entrypoint.py"))
+PY
+```
+
+Run with the guard enabled:
+
+```bash
+JAVELIN_EXPECTED_SHA256=<expected-sha256> python your_game_entrypoint.py
+```
+
+Add this near the top of a Python entrypoint:
+
+```python
+from javelin_integrity import guard_script_integrity
+
+guard_script_integrity(__file__)
+```
+
+### C++ executable guard
+
+`AntiCheat.cpp` already includes a CRC32 self-integrity check. Embed the
+expected CRC at build time; the guard exits if the running executable no longer
+matches.
+
+```bash
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```

--- a/javelin_integrity.py
+++ b/javelin_integrity.py
@@ -1,0 +1,57 @@
+"""Optional SHA-256 integrity verification for Python entrypoints.
+
+Set JAVELIN_EXPECTED_SHA256 to the lowercase hex digest of the script that
+should be allowed to run. Leave it unset to disable the guard.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_CODE_INTEGRITY_FAILURE = 0x71
+
+
+def sha256_file(path: str | os.PathLike[str]) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_script_integrity(
+    script_path: str | os.PathLike[str] | None = None,
+    expected_sha256: str | None = None,
+) -> bool:
+    expected = expected_sha256 or os.getenv(EXPECTED_SHA256_ENV)
+    if not expected:
+        return True
+
+    path = Path(script_path or sys.argv[0]).resolve()
+    current = sha256_file(path)
+    return current.lower() == expected.strip().lower()
+
+
+def guard_script_integrity(
+    script_path: str | os.PathLike[str] | None = None,
+    expected_sha256: str | None = None,
+) -> None:
+    if verify_script_integrity(script_path, expected_sha256):
+        return
+
+    print(
+        "[Javelin AntiCheat] Integrity check failed (SHA-256 mismatch). "
+        "Exiting.",
+        file=sys.stderr,
+    )
+    raise SystemExit(EXIT_CODE_INTEGRITY_FAILURE)
+
+
+if __name__ == "__main__":
+    guard_script_integrity()
+    print("[Javelin AntiCheat] Integrity check passed.")

--- a/test_javelin_integrity.py
+++ b/test_javelin_integrity.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from javelin_integrity import (
+    EXIT_CODE_INTEGRITY_FAILURE,
+    guard_script_integrity,
+    sha256_file,
+    verify_script_integrity,
+)
+
+
+class IntegrityTests(unittest.TestCase):
+    def test_verify_script_integrity_allows_matching_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script = Path(temp_dir) / "game.py"
+            script.write_text("print('safe')\n", encoding="utf-8")
+
+            self.assertTrue(verify_script_integrity(script, sha256_file(script)))
+
+    def test_verify_script_integrity_rejects_mismatched_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script = Path(temp_dir) / "game.py"
+            script.write_text("print('tampered')\n", encoding="utf-8")
+
+            self.assertFalse(verify_script_integrity(script, "0" * 64))
+
+    def test_guard_script_integrity_exits_on_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script = Path(temp_dir) / "game.py"
+            script.write_text("print('tampered')\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as exc_info:
+                guard_script_integrity(script, "0" * 64)
+
+            self.assertEqual(exc_info.exception.code, EXIT_CODE_INTEGRITY_FAILURE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `javelin_integrity.py` with optional SHA-256 verification controlled by `JAVELIN_EXPECTED_SHA256`.
- Fail closed with a guarded exit when the expected digest does not match the target script.
- Document how to generate and set expected hashes, plus the existing C++ CRC32 build-time constant flow.
- Add stdlib `unittest` coverage for matching hashes, mismatches, and guarded exit behavior.

## Verification
- `python3 -m unittest -q test_javelin_integrity.py`
- `python3 -m py_compile javelin_integrity.py test_javelin_integrity.py`
- `git diff --check`

/claim #4