### PR TITLE
feat: add baseline anti-cheat monitor

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -2,15 +2,25 @@
 // Javelin Project - Minimal Anti-Cheat guards
 // Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
 
+#ifdef _WIN32
 #include <windows.h>
 #include <tlhelp32.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
 #include <iostream>
 #include <fstream>
-#include <vector>
 #include <string>
-#include <algorithm>
+#include <vector>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+
+static constexpr int kExitDebugger = 0x0DEB;
+static constexpr int kExitSuspiciousProcess = 0x0BAD;
+static constexpr int kExitIntegrityFailure = 0x0C0C;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -26,7 +36,9 @@ static std::vector<std::string> kSuspiciousProcesses = {
 
 // --- Utils ---
 static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
     return s;
 }
 
@@ -44,7 +56,11 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
 }
 
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
-    std::ifstream f(path, std::ios::binary);
+#ifdef _WIN32
+    std::ifstream f(std::filesystem::path(path), std::ios::binary);
+#else
+    std::ifstream f(std::string(path.begin(), path.end()), std::ios::binary);
+#endif
     if (!f) return false;
     f.seekg(0, std::ios::end);
     std::streamsize size = f.tellg();
@@ -57,27 +73,22 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
 
 // --- Checks ---
 static bool checkDebugger() {
+#ifdef _WIN32
     if (IsDebuggerPresent()) return true;
 
-    // Secondary anti-debug: CheckBeingDebugged flag in PEB (best-effort)
-#ifdef _M_IX86
-    // 32-bit: fs:[30h] -> PEB, offset 2 = BeingDebugged (BYTE)
-    __try {
-        BYTE* peb = *(BYTE**)_readfsdword(0x30);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#elif defined(_M_X64)
-    // 64-bit: gs:[60h] -> PEB
-    __try {
-        BYTE* peb = *(BYTE**)_readgsqword(0x60);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#endif
+    BOOL remoteDebugger = FALSE;
+    if (CheckRemoteDebuggerPresent(GetCurrentProcess(), &remoteDebugger) && remoteDebugger) {
+        return true;
+    }
 
     return false;
+#else
+    return false;
+#endif
 }
 
 static bool checkSuspiciousProcesses() {
+#ifdef _WIN32
     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snap == INVALID_HANDLE_VALUE) return false;
 
@@ -100,9 +111,13 @@ static bool checkSuspiciousProcesses() {
 
     CloseHandle(snap);
     return false;
+#else
+    return false;
+#endif
 }
 
 static bool checkSelfIntegrity(uint32_t expectedCrc) {
+#ifdef _WIN32
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -111,6 +126,10 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 
     uint32_t current = crc32(bytes);
     return current == expectedCrc;
+#else
+    (void)expectedCrc;
+    return false;
+#endif
 }
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
@@ -123,18 +142,18 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebugger;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrityFailure;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat guards for both the C++ client and the Python monitor.
+
+## Features
+
+- C++ debugger detection with `IsDebuggerPresent` and `CheckRemoteDebuggerPresent`.
+- C++ suspicious process detection for common cheat/debug tools.
+- Optional C++ executable integrity verification with build-time CRC32.
+- Python debugger detection with `sys.gettrace()` and `IsDebuggerPresent` on Windows.
+- Python suspicious process detection using Windows `tasklist`.
+- Optional Python script integrity verification with `JAVELIN_EXPECTED_SHA256`.
+
+## C++ Client
+
+Build on Windows with a C++17 compiler:
+
+```powershell
+cl /std:c++17 /EHsc AntiCheat.cpp
+```
+
+To enable executable integrity checks, compile once, calculate the CRC32 for the shipped executable, then rebuild with the expected value:
+
+```powershell
+cl /std:c++17 /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+When `JAVELIN_EXPECTED_CRC32` is left as `0`, the CRC guard is disabled and the debugger/process guards still run.
+
+## Python Monitor
+
+Run the monitor directly:
+
+```powershell
+python anti_cheat.py
+```
+
+To enable script integrity checks, calculate the SHA-256 of `anti_cheat.py` and export it before running:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = (Get-FileHash .\anti_cheat.py -Algorithm SHA256).Hash.ToLower()
+python anti_cheat.py
+```
+
+If `JAVELIN_EXPECTED_SHA256` is unset, the Python integrity guard is skipped. If it is set and the script hash does not match, the monitor exits with a guarded non-zero code.
+
+## Tests
+
+```powershell
+python -m unittest discover -s tests
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,159 @@
+"""Baseline Javelin anti-cheat monitor for Python clients.
+
+The monitor mirrors the C++ guard surface: debugger detection, suspicious
+process detection, and optional script integrity verification.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+TAG = "[Javelin AntiCheat]"
+
+EXIT_DEBUGGER = 0x0DEB
+EXIT_SUSPICIOUS_PROCESS = 0x0BAD
+EXIT_INTEGRITY_FAILURE = 0x0C0C
+
+SUSPICIOUS_PROCESSES = {
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+}
+
+
+def normalize_process_name(name: str) -> str:
+    return name.strip().strip('"').lower()
+
+
+def has_python_debugger() -> bool:
+    return sys.gettrace() is not None
+
+
+def has_windows_debugger() -> bool:
+    if platform.system().lower() != "windows":
+        return False
+
+    try:
+        import ctypes
+
+        return bool(ctypes.windll.kernel32.IsDebuggerPresent())
+    except Exception:
+        return False
+
+
+def is_debugger_present() -> bool:
+    return has_python_debugger() or has_windows_debugger()
+
+
+def parse_tasklist_csv(output: str) -> list[str]:
+    rows = csv.reader(output.splitlines())
+    names: list[str] = []
+    for row in rows:
+        if row:
+            names.append(normalize_process_name(row[0]))
+    return names
+
+
+def list_windows_processes() -> list[str]:
+    if platform.system().lower() != "windows":
+        return []
+
+    try:
+        output = subprocess.check_output(
+            ["tasklist", "/fo", "csv", "/nh"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return []
+
+    return parse_tasklist_csv(output)
+
+
+def find_suspicious_process(process_names: Iterable[str]) -> str | None:
+    bad_names = {normalize_process_name(name) for name in SUSPICIOUS_PROCESSES}
+    for process_name in process_names:
+        normalized = normalize_process_name(process_name)
+        if normalized in bad_names:
+            return normalized
+    return None
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def expected_sha256() -> str | None:
+    value = os.environ.get("JAVELIN_EXPECTED_SHA256")
+    if value is None or not value.strip():
+        return None
+    return value.strip().lower()
+
+
+def is_valid_sha256(value: str) -> bool:
+    if len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def verify_script_integrity(script_path: Path | None = None, expected: str | None = None) -> bool:
+    expected_hash = (expected or expected_sha256())
+    if expected_hash is None:
+        return True
+
+    expected_hash = expected_hash.lower()
+    if not is_valid_sha256(expected_hash):
+        return False
+
+    path = script_path or Path(__file__).resolve()
+    if not path.exists() or not path.is_file():
+        return False
+
+    return sha256_file(path) == expected_hash
+
+
+def run_checks(process_names: Iterable[str] | None = None, script_path: Path | None = None) -> int:
+    if is_debugger_present():
+        print(f"{TAG} Debugger detected. Exiting.", file=sys.stderr)
+        return EXIT_DEBUGGER
+
+    names = list(process_names) if process_names is not None else list_windows_processes()
+    suspicious = find_suspicious_process(names)
+    if suspicious:
+        print(f"{TAG} Suspicious process detected: {suspicious}. Exiting.", file=sys.stderr)
+        return EXIT_SUSPICIOUS_PROCESS
+
+    if not verify_script_integrity(script_path=script_path):
+        print(f"{TAG} Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return EXIT_INTEGRITY_FAILURE
+
+    print(f"{TAG} All clear. Continue.")
+    return 0
+
+
+def main() -> int:
+    return run_checks()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anti_cheat.py
+++ b/tests/test_anti_cheat.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import anti_cheat
+
+
+class AntiCheatMonitorTests(unittest.TestCase):
+    def test_parse_tasklist_csv_extracts_names(self):
+        output = '"python.exe","123","Console","1","10,000 K"\n"x64dbg.exe","99","Console","1","5,000 K"'
+
+        self.assertEqual(anti_cheat.parse_tasklist_csv(output), ["python.exe", "x64dbg.exe"])
+
+    def test_find_suspicious_process_matches_case_insensitively(self):
+        match = anti_cheat.find_suspicious_process(["Explorer.EXE", "CheatEngine.exe"])
+
+        self.assertEqual(match, "cheatengine.exe")
+
+    def test_find_suspicious_process_returns_none_for_clean_list(self):
+        self.assertIsNone(anti_cheat.find_suspicious_process(["python.exe", "game.exe"]))
+
+    def test_integrity_check_allows_missing_expected_hash(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(anti_cheat.verify_script_integrity(Path(__file__)))
+
+    def test_integrity_check_accepts_matching_hash(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            temp.write(b"trusted script")
+            temp_path = Path(temp.name)
+
+        try:
+            expected = anti_cheat.sha256_file(temp_path)
+            self.assertTrue(anti_cheat.verify_script_integrity(temp_path, expected))
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_integrity_check_rejects_mismatch(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            temp.write(b"tampered script")
+            temp_path = Path(temp.name)
+
+        try:
+            self.assertFalse(anti_cheat.verify_script_integrity(temp_path, "0" * 64))
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_integrity_check_rejects_malformed_expected_hash(self):
+        self.assertFalse(anti_cheat.verify_script_integrity(Path(__file__), "not-a-sha"))
+
+    def test_run_checks_exits_on_debugger(self):
+        with mock.patch("anti_cheat.is_debugger_present", return_value=True):
+            code = anti_cheat.run_checks(process_names=[])
+
+        self.assertEqual(code, anti_cheat.EXIT_DEBUGGER)
+
+    def test_run_checks_exits_on_suspicious_process(self):
+        with mock.patch("anti_cheat.is_debugger_present", return_value=False):
+            code = anti_cheat.run_checks(process_names=["x64dbg.exe"])
+
+        self.assertEqual(code, anti_cheat.EXIT_SUSPICIOUS_PROCESS)
+
+    def test_run_checks_exits_on_integrity_failure(self):
+        with mock.patch("anti_cheat.is_debugger_present", return_value=False), mock.patch(
+            "anti_cheat.verify_script_integrity", return_value=False
+        ):
+            code = anti_cheat.run_checks(process_names=[])
+
+        self.assertEqual(code, anti_cheat.EXIT_INTEGRITY_FAILURE)
+
+    def test_run_checks_returns_zero_when_all_clear(self):
+        with mock.patch("anti_cheat.is_debugger_present", return_value=False), mock.patch(
+            "anti_cheat.verify_script_integrity", return_value=True
+        ):
+            code = anti_cheat.run_checks(process_names=["python.exe"])
+
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #2
/claim #4

## Summary
- makes the native `AntiCheat.cpp` build cleanly with MSVC while preserving Windows debugger and suspicious-process checks
- adds a dependency-light `anti_cheat.py` monitor for Python clients with debugger detection, suspicious process detection, and opt-in SHA-256 script integrity verification
- documents the C++ CRC32 and Python SHA-256 integrity setup flows
- adds focused Python regression tests for parsing, suspicious-process matching, integrity success/failure, and guarded exit codes

## Verification
- `py -m unittest discover -s tests` -> 11 tests passed
- `py -m py_compile anti_cheat.py tests\test_anti_cheat.py`
- `cl /std:c++17 /EHsc AntiCheat.cpp /Fe:AntiCheat.exe`
- `AntiCheat.exe` -> `[Javelin AntiCheat] All clear. Continue.`
- `git diff --check`

This was AI-assisted and manually reviewed/tested before submission.