### PR TITLE
feat: add baseline anti-cheat guards

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,121 +1,259 @@
 // AntiCheat.cpp
-// Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Javelin Project - baseline anti-cheat guards.
+//
+// The client exits when a debugger is attached or a known cheat/debugging tool
+// is running. Windows uses native APIs; other platforms keep the file buildable
+// and provide best-effort process/debugger checks for CI validation.
 
-#include <windows.h>
-#include <tlhelp32.h>
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
 
-static const char* kTag = "[Javelin AntiCheat] ";
+#ifdef _WIN32
+#include <tlhelp32.h>
+#include <windows.h>
+#else
+#include <array>
+#include <cstdio>
+#include <memory>
+#endif
 
-// --- Configurable lists ---
-static std::vector<std::string> kSuspiciousProcesses = {
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+constexpr const char* kTag = "[Javelin AntiCheat] ";
+constexpr int kDebuggerExitCode = 0xDEB;
+constexpr int kSuspiciousProcessExitCode = 0xBAD;
+constexpr int kIntegrityExitCode = 0xC0DE;
+
+const std::vector<std::string> kSuspiciousProcesses = {
     "cheatengine.exe",
+    "cheatengine",
     "ollydbg.exe",
+    "ollydbg",
     "x64dbg.exe",
+    "x64dbg",
+    "x32dbg.exe",
+    "x32dbg",
     "httpdebuggerui.exe",
+    "httpdebuggerui",
     "ida.exe",
+    "ida",
     "ida64.exe",
+    "ida64",
     "scylla.exe",
-    "processhacker.exe"
+    "scylla",
+    "processhacker.exe",
+    "processhacker",
+    "frida-server",
+    "frida-trace"
 };
 
-// --- Utils ---
-static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-    return s;
+std::string toLower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
 }
 
-// Simple CRC32 (polynomial 0xEDB88320)
-static uint32_t crc32(const std::vector<uint8_t>& data) {
+std::string basename(std::string value) {
+    const auto slash = value.find_last_of("/\\");
+    if (slash != std::string::npos) {
+        value = value.substr(slash + 1);
+    }
+    return toLower(value);
+}
+
+bool isSuspiciousName(const std::string& processName) {
+    const std::string normalized = basename(processName);
+    return std::find(kSuspiciousProcesses.begin(), kSuspiciousProcesses.end(), normalized) !=
+           kSuspiciousProcesses.end();
+}
+
+uint32_t crc32(const std::vector<uint8_t>& data) {
     uint32_t crc = 0xFFFFFFFFu;
-    for (uint8_t b : data) {
-        crc ^= b;
-        for (int i = 0; i < 8; ++i) {
-            uint32_t mask = -(crc & 1u);
+    for (uint8_t byte : data) {
+        crc ^= byte;
+        for (int bit = 0; bit < 8; ++bit) {
+            const uint32_t mask = -(crc & 1u);
             crc = (crc >> 1) ^ (0xEDB88320u & mask);
         }
     }
     return ~crc;
 }
 
-static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
-    std::ifstream f(path, std::ios::binary);
-    if (!f) return false;
-    f.seekg(0, std::ios::end);
-    std::streamsize size = f.tellg();
-    if (size <= 0) return false;
-    f.seekg(0, std::ios::beg);
-    out.resize(static_cast<size_t>(size));
-    if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
-    return true;
-}
-
-// --- Checks ---
-static bool checkDebugger() {
-    if (IsDebuggerPresent()) return true;
-
-    // Secondary anti-debug: CheckBeingDebugged flag in PEB (best-effort)
-#ifdef _M_IX86
-    // 32-bit: fs:[30h] -> PEB, offset 2 = BeingDebugged (BYTE)
-    __try {
-        BYTE* peb = *(BYTE**)_readfsdword(0x30);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#elif defined(_M_X64)
-    // 64-bit: gs:[60h] -> PEB
-    __try {
-        BYTE* peb = *(BYTE**)_readgsqword(0x60);
-        if (peb && peb[2]) return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#endif
-
-    return false;
-}
-
-static bool checkSuspiciousProcesses() {
-    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (snap == INVALID_HANDLE_VALUE) return false;
-
-    PROCESSENTRY32 pe{};
-    pe.dwSize = sizeof(pe);
-    if (!Process32First(snap, &pe)) {
-        CloseHandle(snap);
+bool readFile(const std::string& path, std::vector<uint8_t>& out) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
         return false;
     }
 
-    do {
-        std::string name = toLower(pe.szExeFile);
-        for (const auto& bad : kSuspiciousProcesses) {
-            if (name == toLower(bad)) {
-                CloseHandle(snap);
-                return true;
-            }
-        }
-    } while (Process32Next(snap, &pe));
+    file.seekg(0, std::ios::end);
+    const std::streamsize size = file.tellg();
+    if (size <= 0) {
+        return false;
+    }
 
-    CloseHandle(snap);
+    file.seekg(0, std::ios::beg);
+    out.resize(static_cast<size_t>(size));
+    return static_cast<bool>(file.read(reinterpret_cast<char*>(out.data()), size));
+}
+
+#ifdef _WIN32
+std::string wideToUtf8(const wchar_t* value) {
+    if (!value || value[0] == L'\0') {
+        return {};
+    }
+
+    const int required = WideCharToMultiByte(CP_UTF8, 0, value, -1, nullptr, 0, nullptr, nullptr);
+    if (required <= 1) {
+        return {};
+    }
+
+    std::string out(static_cast<size_t>(required), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, value, -1, out.data(), required, nullptr, nullptr);
+    out.pop_back();
+    return out;
+}
+
+bool checkDebugger() {
+    if (IsDebuggerPresent()) {
+        return true;
+    }
+
+    BOOL remoteDebugger = FALSE;
+    if (CheckRemoteDebuggerPresent(GetCurrentProcess(), &remoteDebugger) && remoteDebugger) {
+        return true;
+    }
+
     return false;
 }
 
-static bool checkSelfIntegrity(uint32_t expectedCrc) {
-    wchar_t path[MAX_PATH]{};
-    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+std::vector<std::string> listProcessNames() {
+    std::vector<std::string> names;
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snapshot == INVALID_HANDLE_VALUE) {
+        return names;
+    }
 
-    std::vector<uint8_t> bytes;
-    if (!readFile(path, bytes)) return false;
+    PROCESSENTRY32W entry{};
+    entry.dwSize = sizeof(entry);
+    if (!Process32FirstW(snapshot, &entry)) {
+        CloseHandle(snapshot);
+        return names;
+    }
 
-    uint32_t current = crc32(bytes);
-    return current == expectedCrc;
+    do {
+        names.push_back(wideToUtf8(entry.szExeFile));
+    } while (Process32NextW(snapshot, &entry));
+
+    CloseHandle(snapshot);
+    return names;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
+std::string executablePath() {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) {
+        return {};
+    }
+    return wideToUtf8(path);
+}
+#else
+bool checkDebugger() {
+#if defined(__APPLE__)
+    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
+    struct kinfo_proc info {};
+    size_t size = sizeof(info);
+    if (sysctl(mib, 4, &info, &size, nullptr, 0) == 0) {
+        return (info.kp_proc.p_flag & P_TRACED) != 0;
+    }
+    return false;
+#elif defined(__linux__)
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("TracerPid:", 0) == 0) {
+            const int tracerPid = std::atoi(line.substr(10).c_str());
+            return tracerPid != 0;
+        }
+    }
+    return false;
+#else
+    return false;
+#endif
+}
+
+std::vector<std::string> listProcessNames() {
+    std::vector<std::string> names;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("ps -axo comm=", "r"), pclose);
+    if (!pipe) {
+        return names;
+    }
+
+    std::array<char, 512> buffer{};
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
+        std::string name(buffer.data());
+        while (!name.empty() && (name.back() == '\n' || name.back() == '\r')) {
+            name.pop_back();
+        }
+        if (!name.empty()) {
+            names.push_back(name);
+        }
+    }
+    return names;
+}
+
+std::string executablePath() {
+#if defined(__linux__)
+    std::array<char, 4096> path{};
+    const ssize_t length = readlink("/proc/self/exe", path.data(), path.size() - 1);
+    if (length <= 0) {
+        return {};
+    }
+    return std::string(path.data(), static_cast<size_t>(length));
+#else
+    return {};
+#endif
+}
+#endif
+
+bool checkSuspiciousProcesses() {
+    for (const auto& name : listProcessNames()) {
+        if (isSuspiciousName(name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool checkSelfIntegrity(uint32_t expectedCrc) {
+    const std::string path = executablePath();
+    if (path.empty()) {
+        return false;
+    }
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) {
+        return false;
+    }
+
+    return crc32(bytes) == expectedCrc;
+}
+
+}  // namespace
+
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u
 #endif
 
 int main() {
@@ -123,19 +261,17 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kDebuggerExitCode;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kSuspiciousProcessExitCode;
     }
 
-    if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
-        }
+    if (JAVELIN_EXPECTED_CRC32 != 0u && !checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
+        std::cerr << kTag << "Integrity check failed. Exiting.\n";
+        return kIntegrityExitCode;
     }
 
     std::cout << kTag << "All clear. Continue.\n";

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # py-workedtask
+
+Baseline anti-cheat protection for the Javelin Project.
+
+## Components
+
+- `AntiCheat.cpp`: native client guard for debugger and suspicious process detection.
+- `anti_cheat.py`: Python monitor with the same baseline checks.
+
+Both paths block known cheat/debugging tools such as Cheat Engine, x64dbg,
+OllyDbg, IDA, Process Hacker, and Frida utilities.
+
+## Run
+
+```sh
+python3 anti_cheat.py
+```
+
+Build the native client:
+
+```sh
+c++ -std=c++17 -Wall -Wextra -pedantic AntiCheat.cpp -o javelin-anticheat
+./javelin-anticheat
+```
+
+On Windows, build `AntiCheat.cpp` with MSVC or another compiler that provides
+the Windows SDK headers.
+
+## Test
+
+```sh
+python3 -m unittest discover -s tests
+c++ -std=c++17 -Wall -Wextra -pedantic AntiCheat.cpp -o /tmp/javelin-anticheat-check
+/tmp/javelin-anticheat-check
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,132 @@
+"""Baseline Python anti-cheat monitor for the Javelin project."""
+
+from __future__ import annotations
+
+import csv
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import PurePath
+from typing import Iterable
+
+
+class ExitCode(IntEnum):
+    OK = 0
+    DEBUGGER_DETECTED = 0xDEB
+    SUSPICIOUS_PROCESS_DETECTED = 0xBAD
+
+
+SUSPICIOUS_PROCESSES = frozenset(
+    {
+        "cheatengine.exe",
+        "cheatengine",
+        "ollydbg.exe",
+        "ollydbg",
+        "x64dbg.exe",
+        "x64dbg",
+        "x32dbg.exe",
+        "x32dbg",
+        "httpdebuggerui.exe",
+        "httpdebuggerui",
+        "ida.exe",
+        "ida",
+        "ida64.exe",
+        "ida64",
+        "scylla.exe",
+        "scylla",
+        "processhacker.exe",
+        "processhacker",
+        "frida-server",
+        "frida-trace",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    ok: bool
+    exit_code: ExitCode
+    message: str
+
+
+def _normalize_process_name(name: str) -> str:
+    return PurePath(name.strip()).name.lower()
+
+
+def is_debugger_attached() -> bool:
+    if sys.gettrace() is not None:
+        return True
+
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            return bool(ctypes.windll.kernel32.IsDebuggerPresent())
+        except (AttributeError, OSError):
+            return False
+
+    return False
+
+
+def _windows_process_names() -> list[str]:
+    completed = subprocess.run(
+        ["tasklist", "/fo", "csv", "/nh"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return []
+
+    return [row[0] for row in csv.reader(completed.stdout.splitlines()) if row]
+
+
+def _posix_process_names() -> list[str]:
+    completed = subprocess.run(
+        ["ps", "-axo", "comm="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return []
+
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+
+
+def iter_process_names() -> list[str]:
+    if os.name == "nt":
+        return _windows_process_names()
+    return _posix_process_names()
+
+
+def has_suspicious_process(process_names: Iterable[str] | None = None) -> bool:
+    names = iter_process_names() if process_names is None else process_names
+    return any(_normalize_process_name(name) in SUSPICIOUS_PROCESSES for name in names)
+
+
+def run_checks(process_names: Iterable[str] | None = None) -> CheckResult:
+    if is_debugger_attached():
+        return CheckResult(False, ExitCode.DEBUGGER_DETECTED, "Debugger detected")
+
+    if has_suspicious_process(process_names):
+        return CheckResult(
+            False,
+            ExitCode.SUSPICIOUS_PROCESS_DETECTED,
+            "Suspicious process detected",
+        )
+
+    return CheckResult(True, ExitCode.OK, "All clear")
+
+
+def main() -> int:
+    result = run_checks()
+    stream = sys.stdout if result.ok else sys.stderr
+    print(f"[Javelin AntiCheat] {result.message}", file=stream)
+    return int(result.exit_code)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anti_cheat.py
+++ b/tests/test_anti_cheat.py
@@ -1,0 +1,56 @@
+import sys
+import unittest
+from unittest import mock
+
+import anti_cheat
+from anti_cheat import ExitCode
+
+
+class AntiCheatMonitorTests(unittest.TestCase):
+    def test_suspicious_process_detection_matches_known_tools(self):
+        process_names = ["WindowServer", "/tmp/CheatEngine.exe", "python3"]
+
+        self.assertTrue(anti_cheat.has_suspicious_process(process_names))
+
+    def test_suspicious_process_detection_allows_clean_process_list(self):
+        process_names = ["launchd", "python3", "node"]
+
+        self.assertFalse(anti_cheat.has_suspicious_process(process_names))
+
+    def test_debugger_detection_uses_python_trace_hook(self):
+        with mock.patch.object(sys, "gettrace", return_value=lambda *_: None):
+            self.assertTrue(anti_cheat.is_debugger_attached())
+
+    def test_run_checks_returns_debugger_exit_code_first(self):
+        with mock.patch.object(anti_cheat, "is_debugger_attached", return_value=True):
+            result = anti_cheat.run_checks(["cheatengine.exe"])
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.exit_code, ExitCode.DEBUGGER_DETECTED)
+
+    def test_run_checks_returns_suspicious_process_exit_code(self):
+        with mock.patch.object(anti_cheat, "is_debugger_attached", return_value=False):
+            result = anti_cheat.run_checks(["x64dbg.exe"])
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.exit_code, ExitCode.SUSPICIOUS_PROCESS_DETECTED)
+
+    def test_run_checks_allows_clean_environment(self):
+        with mock.patch.object(anti_cheat, "is_debugger_attached", return_value=False):
+            result = anti_cheat.run_checks(["python3", "node"])
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.exit_code, ExitCode.OK)
+
+    def test_main_exits_with_detection_code(self):
+        result = anti_cheat.CheckResult(
+            ok=False,
+            exit_code=ExitCode.SUSPICIOUS_PROCESS_DETECTED,
+            message="Suspicious process detected",
+        )
+        with mock.patch.object(anti_cheat, "run_checks", return_value=result):
+            self.assertEqual(anti_cheat.main(), int(ExitCode.SUSPICIOUS_PROCESS_DETECTED))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
Closes #2

## Summary
- replaces the native client with buildable baseline anti-cheat guards for debugger detection and suspicious process detection
- keeps Windows native checks through `IsDebuggerPresent`, `CheckRemoteDebuggerPresent`, and ToolHelp process enumeration, with POSIX fallbacks so CI can compile and smoke-test the client
- adds a dependency-free Python monitor with the same debugger/process checks
- adds regression tests for suspicious-process matching, debugger detection, detection priority, and exit-code behavior
- documents exact run/test commands

## Acceptance criteria
- [x] Application exits when a debugger is detected.
- [x] Application exits when a suspicious process is found.
- [x] Works for both C++ client (`AntiCheat.cpp`) and Python monitor (`anti_cheat.py`).

## Demo / verification
Native client smoke run:

```text
[Javelin AntiCheat] starting checks...
[Javelin AntiCheat] All clear. Continue.
```

Python monitor smoke run:

```text
[Javelin AntiCheat] All clear
```

## Validation
- `python3 -m unittest discover -s tests`
- `python3 -m py_compile anti_cheat.py tests/test_anti_cheat.py`
- `c++ -std=c++17 -Wall -Wextra -pedantic AntiCheat.cpp -o /tmp/javelin-anticheat-check`
- `/tmp/javelin-anticheat-check`
- `git diff --check`

/claim #2