### PR TITLE
feat: add optional integrity verification guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -4,6 +4,8 @@
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <cstdint>
+#include <cctype>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,6 +13,9 @@
 #include <algorithm>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static constexpr int kExitDebuggerDetected = 0xDEB;
+static constexpr int kExitSuspiciousProcess = 0xBAD;
+static constexpr int kExitIntegrityFailure = 0xC7C;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -26,7 +31,9 @@ static std::vector<std::string> kSuspiciousProcesses = {
 
 // --- Utils ---
 static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
     return s;
 }
 
@@ -81,9 +88,9 @@ static bool checkSuspiciousProcesses() {
     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snap == INVALID_HANDLE_VALUE) return false;
 
-    PROCESSENTRY32 pe{};
+    PROCESSENTRY32A pe{};
     pe.dwSize = sizeof(pe);
-    if (!Process32First(snap, &pe)) {
+    if (!Process32FirstA(snap, &pe)) {
         CloseHandle(snap);
         return false;
     }
@@ -96,7 +103,7 @@ static bool checkSuspiciousProcesses() {
                 return true;
             }
         }
-    } while (Process32Next(snap, &pe));
+    } while (Process32NextA(snap, &pe));
 
     CloseHandle(snap);
     return false;
@@ -123,18 +130,18 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebuggerDetected;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrityFailure;
         }
     }
 

--- a/AntiCheat.py
+++ b/AntiCheat.py
@@ -1,0 +1,69 @@
+"""Minimal Python-side Javelin anti-cheat guards."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_INTEGRITY_FAILURE = 0xC7C
+
+
+def file_sha256(path: str | os.PathLike[str]) -> str:
+    """Return the SHA-256 hex digest for a file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def expected_sha256_from_env() -> str | None:
+    expected = os.environ.get(EXPECTED_SHA256_ENV)
+    if expected is None:
+        return None
+
+    expected = expected.strip().lower()
+    if not expected:
+        return None
+    return expected
+
+
+def check_script_integrity(
+    script_path: str | os.PathLike[str] | None = None,
+    expected_sha256: str | None = None,
+) -> bool:
+    """Compare the current script hash with the expected SHA-256 value.
+
+    The check is disabled when no expected hash is supplied.
+    """
+    expected_sha256 = expected_sha256 or expected_sha256_from_env()
+    if expected_sha256 is None:
+        return True
+
+    path = Path(script_path) if script_path is not None else Path(__file__)
+    current_sha256 = file_sha256(path)
+    return current_sha256 == expected_sha256.lower()
+
+
+def guarded_exit_if_tampered(
+    script_path: str | os.PathLike[str] | None = None,
+    expected_sha256: str | None = None,
+) -> None:
+    if not check_script_integrity(script_path, expected_sha256):
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        raise SystemExit(EXIT_INTEGRITY_FAILURE)
+
+
+def main() -> int:
+    print(f"{TAG}starting checks...")
+    guarded_exit_if_tampered()
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat guards for C++ and Python.
+
+## C++ Integrity Verification
+
+`AntiCheat.cpp` supports an optional executable integrity check. Build once, compute
+the CRC32 of the shipped executable, then embed it in production builds:
+
+```powershell
+cl /std:c++17 /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+When `JAVELIN_EXPECTED_CRC32` is left as `0`, the integrity check is disabled.
+When it is set and the running executable hash does not match, the guard exits
+with a non-zero integrity failure code.
+
+## Python Integrity Verification
+
+`AntiCheat.py` supports an optional SHA-256 integrity check for the running
+script. Set `JAVELIN_EXPECTED_SHA256` to the expected lowercase or uppercase
+SHA-256 digest:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "expected_sha256_hex_digest"
+python AntiCheat.py
+```
+
+When `JAVELIN_EXPECTED_SHA256` is unset or empty, the integrity check is
+disabled. When it is set and the script hash does not match, the guard exits
+with a non-zero integrity failure code.
+
+## Tests
+
+```powershell
+python -m pytest
+```

--- a/test_anticheat.py
+++ b/test_anticheat.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from AntiCheat import (
+    EXIT_INTEGRITY_FAILURE,
+    check_script_integrity,
+    file_sha256,
+    guarded_exit_if_tampered,
+)
+
+
+def test_file_sha256_returns_expected_digest(tmp_path):
+    script = tmp_path / "guard.py"
+    script.write_bytes(b"print('protected')\n")
+
+    assert file_sha256(script) == hashlib.sha256(b"print('protected')\n").hexdigest()
+
+
+def test_script_integrity_is_disabled_without_expected_hash(tmp_path):
+    script = tmp_path / "guard.py"
+    script.write_text("tampered", encoding="utf-8")
+
+    assert check_script_integrity(script)
+
+
+def test_script_integrity_accepts_matching_hash(tmp_path):
+    script = tmp_path / "guard.py"
+    script.write_bytes(b"trusted")
+    expected_hash = hashlib.sha256(b"trusted").hexdigest()
+
+    assert check_script_integrity(script, expected_hash)
+
+
+def test_guarded_exit_on_mismatched_hash(tmp_path):
+    script = tmp_path / "guard.py"
+    script.write_bytes(b"tampered")
+
+    with pytest.raises(SystemExit) as exc_info:
+        guarded_exit_if_tampered(script, "0" * 64)
+
+    assert exc_info.value.code == EXIT_INTEGRITY_FAILURE


### PR DESCRIPTION
Refs #4.

Summary:
- Add optional SHA-256 integrity verification for the Python anti-cheat script.
- Document the expected hash environment variable flow.
- Add tests for no-hash, matching-hash, and mismatched-hash execution paths.
- Fix the C++ integrity-check compile path while keeping behavior aligned with the issue.

Validation:
- python -m pytest -q
- python -m py_compile AntiCheat.py test_anticheat.py
- python AntiCheat.py with no JAVELIN_EXPECTED_SHA256
- python AntiCheat.py with matching JAVELIN_EXPECTED_SHA256
- python AntiCheat.py with mismatched JAVELIN_EXPECTED_SHA256

Note:
- C++ compilation was not run locally because cl.exe, g++.exe, clang++.exe, and clang-cl.exe are not installed or not on PATH in this environment.
