### PR TITLE
Add optional integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,16 +1,24 @@
 // AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, optional self-integrity (CRC32)
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <cctype>
+#include <cstdint>
 #include <iostream>
-#include <fstream>
+#include <limits>
 #include <vector>
 #include <string>
 #include <algorithm>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static constexpr int kExitDebugger = 0x0DEB;
+static constexpr int kExitSuspiciousProcess = 0x0BAD;
+static constexpr int kExitIntegrity = 0xC0DE;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -26,7 +34,9 @@ static std::vector<std::string> kSuspiciousProcesses = {
 
 // --- Utils ---
 static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
     return s;
 }
 
@@ -44,14 +54,43 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
 }
 
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
-    std::ifstream f(path, std::ios::binary);
-    if (!f) return false;
-    f.seekg(0, std::ios::end);
-    std::streamsize size = f.tellg();
-    if (size <= 0) return false;
-    f.seekg(0, std::ios::beg);
-    out.resize(static_cast<size_t>(size));
-    if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
+    HANDLE file = CreateFileW(
+        path.c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    if (file == INVALID_HANDLE_VALUE) return false;
+
+    LARGE_INTEGER fileSize{};
+    if (!GetFileSizeEx(file, &fileSize) || fileSize.QuadPart <= 0) {
+        CloseHandle(file);
+        return false;
+    }
+
+    auto fileSizeBytes = static_cast<unsigned long long>(fileSize.QuadPart);
+    if (fileSizeBytes > static_cast<unsigned long long>(std::numeric_limits<size_t>::max())) {
+        CloseHandle(file);
+        return false;
+    }
+
+    out.resize(static_cast<size_t>(fileSizeBytes));
+    size_t offset = 0;
+    while (offset < out.size()) {
+        DWORD bytesToRead = static_cast<DWORD>(
+            std::min<size_t>(out.size() - offset, 1024 * 1024));
+        DWORD bytesRead = 0;
+        if (!ReadFile(file, out.data() + offset, bytesToRead, &bytesRead, nullptr) ||
+            bytesRead == 0) {
+            CloseHandle(file);
+            return false;
+        }
+        offset += bytesRead;
+    }
+
+    CloseHandle(file);
     return true;
 }
 
@@ -60,13 +99,13 @@ static bool checkDebugger() {
     if (IsDebuggerPresent()) return true;
 
     // Secondary anti-debug: CheckBeingDebugged flag in PEB (best-effort)
-#ifdef _M_IX86
+#if defined(_MSC_VER) && defined(_M_IX86)
     // 32-bit: fs:[30h] -> PEB, offset 2 = BeingDebugged (BYTE)
     __try {
         BYTE* peb = *(BYTE**)_readfsdword(0x30);
         if (peb && peb[2]) return true;
     } __except (EXCEPTION_EXECUTE_HANDLER) {}
-#elif defined(_M_X64)
+#elif defined(_MSC_VER) && defined(_M_X64)
     // 64-bit: gs:[60h] -> PEB
     __try {
         BYTE* peb = *(BYTE**)_readgsqword(0x60);
@@ -81,9 +120,9 @@ static bool checkSuspiciousProcesses() {
     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (snap == INVALID_HANDLE_VALUE) return false;
 
-    PROCESSENTRY32 pe{};
+    PROCESSENTRY32A pe{};
     pe.dwSize = sizeof(pe);
-    if (!Process32First(snap, &pe)) {
+    if (!Process32FirstA(snap, &pe)) {
         CloseHandle(snap);
         return false;
     }
@@ -96,7 +135,7 @@ static bool checkSuspiciousProcesses() {
                 return true;
             }
         }
-    } while (Process32Next(snap, &pe));
+    } while (Process32NextA(snap, &pe));
 
     CloseHandle(snap);
     return false;
@@ -104,7 +143,8 @@ static bool checkSuspiciousProcesses() {
 
 static bool checkSelfIntegrity(uint32_t expectedCrc) {
     wchar_t path[MAX_PATH]{};
-    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+    DWORD length = GetModuleFileNameW(nullptr, path, MAX_PATH);
+    if (length == 0 || length == MAX_PATH) return false;
 
     std::vector<uint8_t> bytes;
     if (!readFile(path, bytes)) return false;
@@ -115,7 +155,7 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u  // Set at build time, e.g. /DJAVELIN_EXPECTED_CRC32=0x12345678.
 #endif
 
 int main() {
@@ -123,18 +163,18 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebugger;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrity;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat guards in C++ and Python.
+
+## C++ integrity check
+
+`AntiCheat.cpp` computes CRC32 over the running executable. The check is optional
+and is disabled when `JAVELIN_EXPECTED_CRC32` is left at its default `0u`.
+
+Build without integrity enforcement:
+
+```powershell
+cl /EHsc AntiCheat.cpp
+```
+
+Compute the CRC32 for the executable you want to trust:
+
+```powershell
+python -c "import pathlib,zlib; p=pathlib.Path(r'.\AntiCheat.exe'); print(f'0x{zlib.crc32(p.read_bytes()) & 0xffffffff:08X}')"
+```
+
+Build with the expected CRC32 as a build-time constant:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+For MinGW or other GCC-compatible toolchains, use:
+
+```powershell
+g++ -std=c++17 -DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp -o AntiCheat.exe
+```
+
+If the computed CRC32 does not match the build-time value, the program exits via
+the guarded integrity path.
+
+The expected CRC must match the exact executable bytes that will run. If your
+release flow embeds or patches the constant after linking, compute the final
+trusted value from the same artifact that will be shipped.
+
+## Python integrity check
+
+`anti_cheat.py` computes SHA-256 over the script file. The check is optional and
+is disabled when `JAVELIN_EXPECTED_SHA256` is unset or empty.
+
+Compute the expected SHA-256:
+
+```powershell
+python -c "import hashlib,pathlib; print(hashlib.sha256(pathlib.Path('anti_cheat.py').read_bytes()).hexdigest())"
+```
+
+Set the expected value for the current PowerShell session and run the guard:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "<sha256 from previous command>"
+python .\anti_cheat.py
+```
+
+If the script bytes do not match `JAVELIN_EXPECTED_SHA256`, the Python guard exits
+through the integrity failure path.
+
+## Tests
+
+```powershell
+python -m unittest
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,133 @@
+"""Minimal Javelin anti-cheat guards for Python."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+from pathlib import Path
+import string
+import sys
+
+try:
+    import psutil  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - depends on caller environment.
+    psutil = None  # type: ignore[assignment]
+
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_DEBUGGER = 0x0DEB
+EXIT_SUSPICIOUS_PROCESS = 0x0BAD
+EXIT_INTEGRITY = 0xC0DE
+HAS_WIN = os.name == "nt"
+
+SUSPICIOUS_PROCESSES = {
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+}
+
+
+def sha256_file(path: str | os.PathLike[str]) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_sha256(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if normalized.startswith("sha256:"):
+        normalized = normalized[len("sha256:") :]
+
+    if len(normalized) != 64:
+        return None
+    if any(ch not in string.hexdigits.lower() for ch in normalized):
+        return None
+    return normalized
+
+
+def check_script_integrity(
+    script_path: str | os.PathLike[str] | None = None,
+    expected_sha256: str | None = None,
+) -> bool:
+    raw_expected = (
+        os.environ.get(EXPECTED_SHA256_ENV)
+        if expected_sha256 is None
+        else expected_sha256
+    )
+    if raw_expected is None or raw_expected.strip() == "":
+        return True
+
+    expected = _normalize_sha256(raw_expected)
+    if expected is None:
+        return False
+
+    path = Path(script_path) if script_path is not None else Path(__file__)
+    return sha256_file(path) == expected
+
+
+def is_debugger_present() -> bool:
+    if sys.gettrace() is not None:
+        return True
+
+    if not HAS_WIN:
+        return False
+
+    try:
+        return bool(ctypes.windll.kernel32.IsDebuggerPresent())
+    except (AttributeError, OSError):
+        return False
+
+
+def detect_suspicious_processes() -> str | None:
+    if psutil is None:
+        return None
+
+    for process in psutil.process_iter(["name"]):
+        try:
+            name = (process.info.get("name") or "").lower()
+        except (AttributeError, KeyError, TypeError):
+            continue
+
+        if name in SUSPICIOUS_PROCESSES:
+            return name
+
+    return None
+
+
+def main(script_path: str | os.PathLike[str] | None = None) -> int:
+    print(f"{TAG}starting checks...")
+
+    if not check_script_integrity(script_path):
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return EXIT_INTEGRITY
+
+    if is_debugger_present():
+        print(f"{TAG}Debugger detected. Exiting.", file=sys.stderr)
+        return EXIT_DEBUGGER
+
+    suspicious_process = detect_suspicious_processes()
+    if suspicious_process is not None:
+        print(
+            f"{TAG}Suspicious process detected: {suspicious_process}. Exiting.",
+            file=sys.stderr,
+        )
+        return EXIT_SUSPICIOUS_PROCESS
+
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_anti_cheat.py
+++ b/test_anti_cheat.py
@@ -1,0 +1,84 @@
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import anti_cheat
+
+
+class _Proc:
+    def __init__(self, name):
+        self.info = {"name": name}
+
+
+class AntiCheatTests(unittest.TestCase):
+    def test_integrity_check_skips_when_env_is_unset(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertTrue(anti_cheat.check_script_integrity())
+
+    def test_integrity_check_accepts_matching_hash(self):
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            path = Path(handle.name)
+            handle.write(b"trusted script bytes")
+
+        self.addCleanup(path.unlink)
+        expected = anti_cheat.sha256_file(path)
+
+        self.assertTrue(
+            anti_cheat.check_script_integrity(path, expected_sha256=expected)
+        )
+
+    def test_integrity_check_rejects_mismatched_hash(self):
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            path = Path(handle.name)
+            handle.write(b"tampered script bytes")
+
+        self.addCleanup(path.unlink)
+        wrong_hash = "0" * 64
+
+        self.assertFalse(
+            anti_cheat.check_script_integrity(path, expected_sha256=wrong_hash)
+        )
+
+    def test_main_returns_guarded_exit_on_integrity_mismatch(self):
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            path = Path(handle.name)
+            handle.write(b"tampered script bytes")
+
+        self.addCleanup(path.unlink)
+
+        with mock.patch.dict(
+            "os.environ",
+            {anti_cheat.EXPECTED_SHA256_ENV: "0" * 64},
+            clear=True,
+        ):
+            self.assertEqual(anti_cheat.main(path), anti_cheat.EXIT_INTEGRITY)
+
+    def test_detect_suspicious_processes(self):
+        fake_psutil = types.SimpleNamespace(
+            process_iter=lambda _attrs: iter([_Proc("CheatEngine.exe")])
+        )
+
+        with mock.patch.object(anti_cheat, "psutil", fake_psutil):
+            self.assertEqual(
+                anti_cheat.detect_suspicious_processes(),
+                "cheatengine.exe",
+            )
+
+    def test_no_suspicious_process(self):
+        fake_psutil = types.SimpleNamespace(
+            process_iter=lambda _attrs: iter([_Proc("explorer.exe"), _Proc("notepad.exe")])
+        )
+
+        with mock.patch.object(anti_cheat, "psutil", fake_psutil):
+            self.assertIsNone(anti_cheat.detect_suspicious_processes())
+
+    def test_debugger_present_is_graceful_without_windows_api(self):
+        with mock.patch.object(anti_cheat, "HAS_WIN", False):
+            with mock.patch("sys.gettrace", return_value=None):
+                self.assertFalse(anti_cheat.is_debugger_present())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4

Summary:
- Add optional CRC32 self-integrity enforcement for the Windows C++ executable via `JAVELIN_EXPECTED_CRC32`.
- Add a Python guard that checks the running script SHA-256 against `JAVELIN_EXPECTED_SHA256`.
- Return guarded exit codes for integrity, debugger, and suspicious-process failures.
- Document how to compute and set expected integrity values.

Verification:
- uv run python -m unittest -v
  - Ran 7 tests: OK

Note:
- C++ compile verification was not run locally because no `cl`, `g++`, or `clang++` compiler was available in this environment.