### PR TITLE
Add optional integrity verification guards

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,9 +1,11 @@
 // AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, optional self-integrity (CRC32)
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <cstdint>
+#include <iomanip>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,6 +13,15 @@
 #include <algorithm>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+
+// --- Entry helper (embed a baseline CRC once you ship a build) ---
+#ifndef JAVELIN_EXPECTED_CRC32
+#define JAVELIN_EXPECTED_CRC32 0u  // Set at build time, e.g. /DJAVELIN_EXPECTED_CRC32=0x12345678
+#endif
+
+static constexpr int kExitDebugger = 0x0DEB;
+static constexpr int kExitSuspiciousProcess = 0x0BAD;
+static constexpr int kExitIntegrity = 0x0C0D;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -43,6 +54,45 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
     return ~crc;
 }
 
+static std::vector<uint8_t> expectedCrcMarkerBytes(uint32_t expectedCrc) {
+    return {
+        'J', 'V', 'L', 'N', '_', 'C', 'R', 'C', '3', '2', '_',
+        static_cast<uint8_t>((expectedCrc >> 0) & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 8) & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 16) & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 24) & 0xFFu),
+        '_', 'E', 'N', 'D'
+    };
+}
+
+static const uint8_t kExpectedCrcMarker[] = {
+    'J', 'V', 'L', 'N', '_', 'C', 'R', 'C', '3', '2', '_',
+    static_cast<uint8_t>((JAVELIN_EXPECTED_CRC32 >> 0) & 0xFFu),
+    static_cast<uint8_t>((JAVELIN_EXPECTED_CRC32 >> 8) & 0xFFu),
+    static_cast<uint8_t>((JAVELIN_EXPECTED_CRC32 >> 16) & 0xFFu),
+    static_cast<uint8_t>((JAVELIN_EXPECTED_CRC32 >> 24) & 0xFFu),
+    '_', 'E', 'N', 'D'
+};
+
+static bool findMarkerOffset(const std::vector<uint8_t>& bytes, const std::vector<uint8_t>& marker, size_t& offset) {
+    auto it = std::search(bytes.begin(), bytes.end(), marker.begin(), marker.end());
+    if (it == bytes.end()) return false;
+    offset = static_cast<size_t>(std::distance(bytes.begin(), it));
+    return true;
+}
+
+static bool normalizeEmbeddedExpectedCrc(std::vector<uint8_t>& bytes, uint32_t expectedCrc) {
+    const std::vector<uint8_t> marker = expectedCrcMarkerBytes(expectedCrc);
+    size_t markerOffset = 0;
+    if (!findMarkerOffset(bytes, marker, markerOffset)) return false;
+
+    const size_t crcOffset = markerOffset + 11;
+    for (size_t i = 0; i < 4; ++i) {
+        bytes[crcOffset + i] = 0;
+    }
+    return true;
+}
+
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
     std::ifstream f(path, std::ios::binary);
     if (!f) return false;
@@ -52,6 +102,24 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
     f.seekg(0, std::ios::beg);
     out.resize(static_cast<size_t>(size));
     if (!f.read(reinterpret_cast<char*>(out.data()), size)) return false;
+    return true;
+}
+
+static bool readSelfExecutable(std::vector<uint8_t>& bytes) {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+    return readFile(path, bytes);
+}
+
+static bool computeNormalizedSelfCrc(uint32_t& outCrc) {
+    std::vector<uint8_t> bytes;
+    if (!readSelfExecutable(bytes)) return false;
+
+    if (!normalizeEmbeddedExpectedCrc(bytes, JAVELIN_EXPECTED_CRC32)) {
+        return false;
+    }
+
+    outCrc = crc32(bytes);
     return true;
 }
 
@@ -103,38 +171,41 @@ static bool checkSuspiciousProcesses() {
 }
 
 static bool checkSelfIntegrity(uint32_t expectedCrc) {
-    wchar_t path[MAX_PATH]{};
-    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
-
-    std::vector<uint8_t> bytes;
-    if (!readFile(path, bytes)) return false;
-
-    uint32_t current = crc32(bytes);
+    uint32_t current = 0;
+    if (!computeNormalizedSelfCrc(current)) return false;
     return current == expectedCrc;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
-#ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
-#endif
+int main(int argc, char* argv[]) {
+    (void)kExpectedCrcMarker;
 
-int main() {
+    if (argc > 1 && std::string(argv[1]) == "--print-integrity-crc32") {
+        uint32_t crc = 0;
+        if (!computeNormalizedSelfCrc(crc)) {
+            std::cerr << kTag << "Unable to compute self CRC32.\n";
+            return kExitIntegrity;
+        }
+        std::cout << "0x" << std::hex << std::uppercase << std::setw(8)
+                  << std::setfill('0') << crc << "\n";
+        return 0;
+    }
+
     std::cout << kTag << "starting checks...\n";
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebugger;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrity;
         }
     }
 

--- a/AntiCheat.py
+++ b/AntiCheat.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Minimal Python anti-cheat guard with optional script integrity checking."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_INTEGRITY = 0x0C0D
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def current_script_path() -> Path:
+    return Path(__file__).resolve()
+
+
+def check_script_integrity(expected_sha256: str) -> bool:
+    expected = expected_sha256.strip().lower()
+    if len(expected) != 64 or any(c not in "0123456789abcdef" for c in expected):
+        print(f"{TAG}{EXPECTED_SHA256_ENV} must be a 64-character SHA-256 hex digest.", file=sys.stderr)
+        return False
+
+    current = sha256_file(current_script_path())
+    if current != expected:
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return False
+
+    return True
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--print-integrity-sha256":
+        print(sha256_file(current_script_path()))
+        return 0
+
+    print(f"{TAG}starting checks...")
+
+    expected_sha256 = os.environ.get(EXPECTED_SHA256_ENV)
+    if expected_sha256:
+        if not check_script_integrity(expected_sha256):
+            return EXIT_INTEGRITY
+
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat examples for C++ and Python.
+
+## C++ integrity check
+
+`AntiCheat.cpp` supports debugger detection, suspicious-process detection, and an optional CRC32 self-integrity check for the running executable.
+
+Build once without an expected CRC:
+
+```powershell
+cl /EHsc AntiCheat.cpp /Fe:JavelinAntiCheat.exe
+```
+
+Print the normalized CRC32 for that build:
+
+```powershell
+.\JavelinAntiCheat.exe --print-integrity-crc32
+```
+
+Rebuild with the expected CRC:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp /Fe:JavelinAntiCheat.exe
+```
+
+Replace `0x12345678` with the value printed by the first build. At runtime, if the executable has been modified and the CRC no longer matches, the program exits before continuing.
+
+The embedded expected CRC bytes are normalized before hashing. This avoids the circular problem where changing the expected CRC value changes the executable hash.
+
+## Python integrity check
+
+`AntiCheat.py` supports an optional SHA-256 integrity check of the script file.
+
+Print the expected SHA-256:
+
+```powershell
+python AntiCheat.py --print-integrity-sha256
+```
+
+Run with integrity checking enabled:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "paste-the-64-character-sha256-here"
+python AntiCheat.py
+```
+
+If `JAVELIN_EXPECTED_SHA256` is unset, the Python integrity check is skipped. If it is set and does not match the current script file, the script exits with a guarded integrity failure.


### PR DESCRIPTION
Fixes #4.

Adds optional integrity verification for both implementations:

- C++ executable CRC32 guard with a normalized embedded expected-value marker.
- `--print-integrity-crc32` helper for producing the build-time CRC value.
- Python SHA-256 script guard using `JAVELIN_EXPECTED_SHA256`.
- `--print-integrity-sha256` helper for producing the Python expected hash.
- README instructions for generating and setting expected values.
- Replaces the invalid `0xCRC` return literal with a valid guarded integrity exit code.

Validation performed:

- `python AntiCheat.py --print-integrity-sha256`
- `python AntiCheat.py`
- matching `JAVELIN_EXPECTED_SHA256` run passes
- mismatched `JAVELIN_EXPECTED_SHA256` run exits with an integrity failure
- `git diff --check`

I could not compile the Windows C++ file in this environment because no C++ compiler is installed here.

/claim #4
