### PR TITLE
Add optional C++ and Python integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -9,6 +9,10 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cstdint>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -115,26 +119,30 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u  // Set at build time, e.g. /DJAVELIN_EXPECTED_CRC32=0x12345678
 #endif
+
+static constexpr int kExitDebuggerDetected = 0x0DEB;
+static constexpr int kExitSuspiciousProcess = 0x0BAD;
+static constexpr int kExitIntegrityFailed = 0x0C0C;
 
 int main() {
     std::cout << kTag << "starting checks...\n";
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebuggerDetected;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrityFailed;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat examples for C++ and Python.
+
+## C++ integrity verification
+
+`AntiCheat.cpp` includes an optional self-integrity check. By default the check is disabled. Build with `JAVELIN_EXPECTED_CRC32` set to the expected CRC32 for the shipped executable to enable guarded exit on tampering.
+
+Example MSVC flow:
+
+```powershell
+cl /EHsc AntiCheat.cpp
+.\AntiCheat.exe
+```
+
+After producing a release build, calculate the executable CRC32 with your release tooling and rebuild with the value embedded:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+When the embedded value is non-zero and the running executable hash does not match, the program exits through the integrity-failure guard.
+
+## Python integrity verification
+
+`anti_cheat.py` checks its own SHA-256 when `JAVELIN_EXPECTED_SHA256` is present. Without the environment variable, the integrity check is skipped so local development remains simple.
+
+Calculate the expected hash:
+
+```powershell
+python -c "import hashlib, pathlib; print(hashlib.sha256(pathlib.Path('anti_cheat.py').read_bytes()).hexdigest())"
+```
+
+Run with the expected hash:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "<sha256 from previous command>"
+python anti_cheat.py
+```
+
+If the file changes after the expected hash is set, `anti_cheat.py` prints an integrity-failure message and exits with a guarded non-zero status.

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,47 @@
+"""Minimal Python anti-cheat guard with optional script integrity checking."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_INTEGRITY_FAILED = 0xC0C
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def check_script_integrity(path: Path | None = None) -> bool:
+    """Return True when no expected hash is configured or the script matches it."""
+    expected = os.environ.get(EXPECTED_SHA256_ENV, "").strip().lower()
+    if not expected:
+        return True
+
+    script_path = path or Path(__file__).resolve()
+    current = sha256_file(script_path)
+    return current == expected
+
+
+def main() -> int:
+    print(f"{TAG}starting checks...")
+
+    if not check_script_integrity():
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return EXIT_INTEGRITY_FAILED
+
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #4.

Summary:
- Adds a Python anti-cheat entry point that verifies its own SHA-256 when `JAVELIN_EXPECTED_SHA256` is configured.
- Keeps the C++ CRC32 guard optional through `JAVELIN_EXPECTED_CRC32` and replaces the invalid `0xCRC` return literal with named guarded exit codes.
- Documents how to set the expected C++ CRC32 and Python SHA-256 values.

Verification:
- `python -m py_compile anti_cheat.py` using bundled Python
- `python anti_cheat.py` exits 0 when no expected hash is set
- matching `JAVELIN_EXPECTED_SHA256` exits 0
- mismatched `JAVELIN_EXPECTED_SHA256` exits with guarded status `0xC0C`

Note: I could not compile the Windows C++ file locally because no C++ compiler is installed in this environment.