### PR TITLE
feat: add integrity verification guards

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -4,6 +4,8 @@
 
 #include <windows.h>
 #include <tlhelp32.h>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,6 +13,9 @@
 #include <algorithm>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static const int kExitDebugger = 0x0DEB;
+static const int kExitSuspiciousProcess = 0x0BAD;
+static const int kExitIntegrity = 0x0C0D;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -41,6 +46,30 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
         }
     }
     return ~crc;
+}
+
+static void zeroExpectedCrc32Bytes(std::vector<uint8_t>& bytes, uint32_t expectedCrc) {
+    if (expectedCrc == 0u || bytes.size() < sizeof(expectedCrc)) {
+        return;
+    }
+
+    uint8_t pattern[sizeof(expectedCrc)] = {
+        static_cast<uint8_t>(expectedCrc & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 8) & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 16) & 0xFFu),
+        static_cast<uint8_t>((expectedCrc >> 24) & 0xFFu),
+    };
+
+    for (size_t i = 0; i + sizeof(expectedCrc) <= bytes.size(); ++i) {
+        if (std::memcmp(bytes.data() + i, pattern, sizeof(pattern)) == 0) {
+            std::fill(bytes.begin() + i, bytes.begin() + i + sizeof(expectedCrc), 0u);
+        }
+    }
+}
+
+static uint32_t integrityCrc32(std::vector<uint8_t> bytes, uint32_t expectedCrc) {
+    zeroExpectedCrc32Bytes(bytes, expectedCrc);
+    return crc32(bytes);
 }
 
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
@@ -109,8 +138,19 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     std::vector<uint8_t> bytes;
     if (!readFile(path, bytes)) return false;
 
-    uint32_t current = crc32(bytes);
+    uint32_t current = integrityCrc32(bytes, expectedCrc);
     return current == expectedCrc;
+}
+
+static bool printCurrentIntegrityCrc32() {
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    std::cout << std::hex << integrityCrc32(bytes, 0u) << "\n";
+    return true;
 }
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
@@ -118,23 +158,27 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 #define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
 #endif
 
-int main() {
+int main(int argc, char** argv) {
+    if (argc == 2 && std::string(argv[1]) == "--print-integrity-crc32") {
+        return printCurrentIntegrityCrc32() ? 0 : kExitIntegrity;
+    }
+
     std::cout << kTag << "starting checks...\n";
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebugger;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
         if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
             std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+            return kExitIntegrity;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # py-workedtask
+
+Minimal anti-cheat guards for the Javelin Project.
+
+## C++ client
+
+`AntiCheat.cpp` checks for:
+
+- an attached debugger
+- known suspicious process names
+- optional executable integrity via `JAVELIN_EXPECTED_CRC32`
+
+Build once without `JAVELIN_EXPECTED_CRC32`, then print the integrity CRC for
+that build artifact:
+
+```powershell
+cl /std:c++17 /EHsc AntiCheat.cpp /Fe:AntiCheat.exe
+.\AntiCheat.exe --print-integrity-crc32
+```
+
+Rebuild with the returned value:
+
+```powershell
+cl /std:c++17 /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp /Fe:AntiCheat.exe
+```
+
+When `JAVELIN_EXPECTED_CRC32` is non-zero, a mismatch exits with code `0x0C0D`.
+Leaving it as `0u` disables the integrity check.
+
+## Python monitor
+
+`anti_cheat.py` enables script integrity checks through
+`JAVELIN_EXPECTED_SHA256`.
+
+Print the expected SHA-256 value:
+
+```sh
+python - <<'PY'
+from pathlib import Path
+from anti_cheat import sha256_file
+print(sha256_file(Path("anti_cheat.py")))
+PY
+```
+
+Run with the expected value:
+
+```sh
+JAVELIN_EXPECTED_SHA256=<64-character sha256> python anti_cheat.py
+```
+
+If the script hash does not match, the monitor exits with code `13`. If
+`JAVELIN_EXPECTED_SHA256` is unset or empty, the integrity check is disabled.
+
+## Tests
+
+```sh
+python -m unittest discover -s tests
+python -m py_compile anti_cheat.py tests/test_anti_cheat.py
+```

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,74 @@
+"""Javelin Python anti-cheat integrity guard.
+
+Set JAVELIN_EXPECTED_SHA256 to the SHA-256 hash of this script to enable
+tamper detection. Leaving the variable unset keeps the check disabled.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+TAG = "[Javelin AntiCheat] "
+EXIT_INTEGRITY = 13
+SHA256_HEX_LENGTH = 64
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_expected_sha256(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+
+    if len(normalized) != SHA256_HEX_LENGTH:
+        raise ValueError("expected SHA-256 must be 64 hex characters")
+
+    try:
+        bytes.fromhex(normalized)
+    except ValueError as exc:
+        raise ValueError("expected SHA-256 must be hexadecimal") from exc
+
+    return normalized
+
+
+def check_self_integrity(expected_sha256: str | None = None, script_path: Path | None = None) -> bool:
+    expected = normalize_expected_sha256(
+        expected_sha256 if expected_sha256 is not None else os.environ.get("JAVELIN_EXPECTED_SHA256")
+    )
+    if expected is None:
+        return True
+
+    path = script_path or Path(__file__)
+    return sha256_file(path) == expected
+
+
+def main() -> int:
+    try:
+        ok = check_self_integrity()
+    except (OSError, ValueError) as exc:
+        print(f"{TAG}Integrity configuration failed: {exc}", file=sys.stderr)
+        return EXIT_INTEGRITY
+
+    if not ok:
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return EXIT_INTEGRITY
+
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_anti_cheat.py
+++ b/tests/test_anti_cheat.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import anti_cheat
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "anti_cheat.py"
+
+
+class IntegrityTests(unittest.TestCase):
+    def test_missing_expected_hash_disables_check(self):
+        self.assertTrue(anti_cheat.check_self_integrity(expected_sha256="", script_path=SCRIPT))
+
+    def test_matching_expected_hash_passes(self):
+        expected = anti_cheat.sha256_file(SCRIPT)
+        self.assertTrue(anti_cheat.check_self_integrity(expected_sha256=expected, script_path=SCRIPT))
+
+    def test_mismatched_expected_hash_fails(self):
+        self.assertFalse(anti_cheat.check_self_integrity(expected_sha256="0" * 64, script_path=SCRIPT))
+
+    def test_malformed_expected_hash_raises(self):
+        with self.assertRaises(ValueError):
+            anti_cheat.check_self_integrity(expected_sha256="not-a-sha", script_path=SCRIPT)
+
+    def test_cli_returns_guarded_exit_for_mismatch(self):
+        env = os.environ.copy()
+        env["JAVELIN_EXPECTED_SHA256"] = "0" * 64
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, anti_cheat.EXIT_INTEGRITY)
+        self.assertIn("Integrity check failed", result.stderr)
+
+    def test_cli_accepts_matching_hash(self):
+        env = os.environ.copy()
+        env["JAVELIN_EXPECTED_SHA256"] = anti_cheat.sha256_file(SCRIPT)
+
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("All clear", result.stdout)
+
+    def test_file_hash_changes_after_tamper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "guard.py"
+            path.write_text("print('clean')\n", encoding="utf-8")
+            original = anti_cheat.sha256_file(path)
+
+            path.write_text("print('tampered')\n", encoding="utf-8")
+
+            self.assertNotEqual(anti_cheat.sha256_file(path), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
/claim #4

## Summary
- replace the invalid native integrity exit path with named guarded exit codes
- add a C++ `--print-integrity-crc32` helper plus normalized expected-CRC comparison for build-time integrity checks
- add `anti_cheat.py` with optional `JAVELIN_EXPECTED_SHA256` script integrity verification
- document how to compute and set expected values for both implementations
- add focused Python regression coverage for missing, matching, malformed, mismatched, and tampered hashes

## Verification
- `python3 -m unittest discover -s tests` -> 7 tests passed
- `python3 -m py_compile anti_cheat.py tests/test_anti_cheat.py`
- `python3 anti_cheat.py` -> `[Javelin AntiCheat] All clear. Continue.`
- `git diff --check`