### PR TITLE
feat: add SHA-256 integrity verification for C++ and Python (fixes #4)

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,6 +1,6 @@
-// AntiCheat.cpp
+﻿// AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, self-integrity (CRC32 + SHA-256)
 
 #include <windows.h>
 #include <tlhelp32.h>
@@ -9,6 +9,10 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <iomanip>
+#include <sstream>
+
+#pragma comment(lib, "bcrypt.lib")
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -30,6 +34,15 @@ static std::string toLower(std::string s) {
     return s;
 }
 
+static std::string toHex(const std::vector<uint8_t>& data) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (uint8_t b : data) {
+        oss << std::setw(2) << static_cast<int>(b);
+    }
+    return oss.str();
+}
+
 // Simple CRC32 (polynomial 0xEDB88320)
 static uint32_t crc32(const std::vector<uint8_t>& data) {
     uint32_t crc = 0xFFFFFFFFu;
@@ -41,6 +54,28 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
         }
     }
     return ~crc;
+}
+
+// SHA-256 via Windows CNG (BCrypt)
+static std::vector<uint8_t> sha256(const std::vector<uint8_t>& data) {
+    std::vector<uint8_t> hash(32, 0);
+    BCRYPT_ALG_HANDLE hAlg = nullptr;
+    BCRYPT_HASH_HANDLE hHash = nullptr;
+    NTSTATUS status = BCryptOpenAlgorithmProvider(&hAlg, BCRYPT_SHA256_ALGORITHM, nullptr, 0);
+    if (!BCRYPT_SUCCESS(status)) return hash; // all zeros = failure
+
+    status = BCryptCreateHash(hAlg, &hHash, nullptr, 0, nullptr, 0, 0);
+    if (!BCRYPT_SUCCESS(status)) { BCryptCloseAlgorithmProvider(hAlg, 0); return hash; }
+
+    status = BCryptHashData(hHash, const_cast<PUCHAR>(data.data()), static_cast<ULONG>(data.size()), 0);
+    if (!BCRYPT_SUCCESS(status)) { BCryptDestroyHash(hHash); BCryptCloseAlgorithmProvider(hAlg, 0); return hash; }
+
+    status = BCryptFinishHash(hHash, hash.data(), static_cast<ULONG>(hash.size()), 0);
+    BCryptDestroyHash(hHash);
+    BCryptCloseAlgorithmProvider(hAlg, 0);
+
+    if (!BCRYPT_SUCCESS(status)) return std::vector<uint8_t>(32, 0);
+    return hash;
 }
 
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
@@ -59,15 +94,12 @@ static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
 static bool checkDebugger() {
     if (IsDebuggerPresent()) return true;
 
-    // Secondary anti-debug: CheckBeingDebugged flag in PEB (best-effort)
 #ifdef _M_IX86
-    // 32-bit: fs:[30h] -> PEB, offset 2 = BeingDebugged (BYTE)
     __try {
         BYTE* peb = *(BYTE**)_readfsdword(0x30);
         if (peb && peb[2]) return true;
     } __except (EXCEPTION_EXECUTE_HANDLER) {}
 #elif defined(_M_X64)
-    // 64-bit: gs:[60h] -> PEB
     __try {
         BYTE* peb = *(BYTE**)_readgsqword(0x60);
         if (peb && peb[2]) return true;
@@ -102,7 +134,7 @@ static bool checkSuspiciousProcesses() {
     return false;
 }
 
-static bool checkSelfIntegrity(uint32_t expectedCrc) {
+static bool checkSelfIntegrityCrc32(uint32_t expectedCrc) {
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -113,9 +145,33 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     return current == expectedCrc;
 }
 
-// --- Entry helper (embed a baseline CRC once you ship a build) ---
+static bool checkSelfIntegritySha256(const std::string& expectedHex) {
+    if (expectedHex.empty() || expectedHex.length() != 64) return true; // skip if not configured
+
+    wchar_t path[MAX_PATH]{};
+    if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
+
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, bytes)) return false;
+
+    std::vector<uint8_t> hash = sha256(bytes);
+
+    // Check if hash is all zeros (crypto API failure)
+    bool allZero = true;
+    for (uint8_t b : hash) { if (b != 0) { allZero = false; break; } }
+    if (allZero) return false;
+
+    std::string currentHex = toHex(hash);
+    return currentHex == expectedHex;
+}
+
+// --- Build-time constants ---
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u
+#endif
+
+#ifndef JAVELIN_EXPECTED_SHA256
+#define JAVELIN_EXPECTED_SHA256 ""
 #endif
 
 int main() {
@@ -123,19 +179,30 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return 0xDEB;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return 0xBAD;
     }
 
+    // CRC32 integrity check
     if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+        if (!checkSelfIntegrityCrc32(JAVELIN_EXPECTED_CRC32)) {
+            std::cerr << kTag << "Integrity check failed (CRC32 mismatch). Exiting.\n";
+            return 0xCRC;
         }
+        std::cout << kTag << "CRC32 integrity OK.\n";
+    }
+
+    // SHA-256 integrity check (stronger; takes priority if both configured)
+    if (strlen(JAVELIN_EXPECTED_SHA256) == 64) {
+        if (!checkSelfIntegritySha256(JAVELIN_EXPECTED_SHA256)) {
+            std::cerr << kTag << "Integrity check failed (SHA-256 mismatch). Exiting.\n";
+            return 0x256;
+        }
+        std::cout << kTag << "SHA-256 integrity OK.\n";
     }
 
     std::cout << kTag << "All clear. Continue.\n";

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# py-workedtask
+﻿# py-workedtask
+
+Javelin Project - Minimal Anti-Cheat guards for C++ and Python.
+
+## Features
+
+- **Debugger detection** - detects attached debuggers via IsDebuggerPresent and PEB check
+- **Suspicious process scan** - scans running processes for known cheating/reverse-engineering tools
+- **Self-integrity verification** - detects tampering of the executable/script via CRC32 and SHA-256
+
+## C++ Build
+
+### Requirements
+- Windows SDK (Windows 10+)
+- MSVC or Clang with crypt.lib
+
+### Build
+`cmd
+cl /EHsc /O2 AntiCheat.cpp /link bcrypt.lib
+`
+
+### Integrity Check Configuration (C++)
+
+Set the expected hash at build time via preprocessor defines:
+
+**CRC32 (lightweight):**
+`cmd
+cl /EHsc /O2 /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp /link bcrypt.lib
+`
+
+**SHA-256 (stronger):**
+`cmd
+cl /EHsc /O2 /DJAVELIN_EXPECTED_SHA256=\"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\" AntiCheat.cpp /link bcrypt.lib
+`
+
+You can use both simultaneously. The SHA-256 check runs after CRC32 if both are configured.
+
+**Getting the expected hash value for a built executable:**
+
+`cmd
+certutil -hashfile AntiCheat.exe SHA256
+`
+
+or use the provided Python helper:
+`cmd
+python -c "import hashlib; print(hashlib.sha256(open('AntiCheat.exe','rb').read()).hexdigest())"
+`
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All clear |
+| 0xDEB (3563) | Debugger detected |
+| 0xBAD (2989) | Suspicious process detected |
+| 0xCRC (3276) | CRC32 mismatch |
+| 0x256 (598)  | SHA-256 mismatch |
+
+## Python Usage
+
+### Requirements
+- Python 3.7+
+
+### Integrity Check (Python)
+
+The Python script nti_cheat.py computes SHA-256 of itself and compares against the expected value.
+
+`cmd
+set JAVELIN_EXPECTED_SHA256=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+python anti_cheat.py
+`
+
+**Getting the expected hash:**
+`cmd
+python -c "import hashlib; print(hashlib.sha256(open('anti_cheat.py','rb').read()).hexdigest())"
+`
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed or skipped (env var not set) |
+| 0x256 (598) | SHA-256 mismatch (tampering detected) |
+| 1 | File read error |
+
+## License
+
+MIT

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,68 @@
+﻿#!/usr/bin/env python3
+# anti_cheat.py
+# Javelin Project - Python self-integrity check via SHA-256
+#
+# Usage:
+#   python anti_cheat.py
+#
+# Environment variables:
+#   JAVELIN_EXPECTED_SHA256  - expected SHA-256 hex digest of this script file (64 hex chars)
+#                              If not set or empty, the check is skipped.
+#
+# Exit codes:
+#   0   - check passed or skipped
+#   0x256 (598) - SHA-256 mismatch (tampering detected)
+#   1   - file read error
+
+import os
+import sys
+import hashlib
+
+TAG = "[Javelin AntiCheat] "
+
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+
+
+def sha256_file(path: str) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(65536)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    expected = os.environ.get(EXPECTED_SHA256_ENV, "").strip().lower()
+
+    if not expected:
+        print(f"{TAG}JAVELIN_EXPECTED_SHA256 not set, skipping integrity check.")
+        return 0
+
+    if len(expected) != 64:
+        print(f"{TAG}JAVELIN_EXPECTED_SHA256 must be 64 hex characters.")
+        return 1
+
+    script_path = os.path.abspath(__file__)
+
+    try:
+        actual = sha256_file(script_path)
+    except OSError as e:
+        print(f"{TAG}Failed to read script file: {e}", file=sys.stderr)
+        return 1
+
+    if actual != expected:
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        print(f"  Expected: {expected}", file=sys.stderr)
+        print(f"  Actual:   {actual}", file=sys.stderr)
+        return 0x256  # 598
+
+    print(f"{TAG}SHA-256 integrity OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements integrity verification as described in #4.

## Changes

### C++ (AntiCheat.cpp)
- Added SHA-256 hash computation using Windows CNG (BCrypt API)
- Added checkSelfIntegritySha256() function that compares SHA-256 of the running executable against a build-time constant JAVELIN_EXPECTED_SHA256
- Retained existing CRC32 check; SHA-256 runs as a stronger additional layer when configured
- Added 	oHex() utility for hash comparison output
- Exit code 