### PR TITLE
Add optional C++ and Python integrity verification

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -9,8 +9,13 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <cctype>
+#include <cstdint>
 
 static const char* kTag = "[Javelin AntiCheat] ";
+static constexpr int kExitDebuggerDetected = 0xDEB;
+static constexpr int kExitSuspiciousProcess = 0xBAD;
+static constexpr int kExitIntegrityFailure = 0x1A;
 
 // --- Configurable lists ---
 static std::vector<std::string> kSuspiciousProcesses = {
@@ -26,7 +31,9 @@ static std::vector<std::string> kSuspiciousProcesses = {
 
 // --- Utils ---
 static std::string toLower(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
     return s;
 }
 
@@ -103,6 +110,8 @@ static bool checkSuspiciousProcesses() {
 }
 
 static bool checkSelfIntegrity(uint32_t expectedCrc) {
+    if (expectedCrc == 0u) return true;
+
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -115,7 +124,7 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
 #ifndef JAVELIN_EXPECTED_CRC32
-#define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#define JAVELIN_EXPECTED_CRC32 0u  // Optional: set at build time, e.g. /DJAVELIN_EXPECTED_CRC32=0x12345678
 #endif
 
 int main() {
@@ -123,19 +132,17 @@ int main() {
 
     if (checkDebugger()) {
         std::cerr << kTag << "Debugger detected. Exiting.\n";
-        return 0xDEB; // code for debugger
+        return kExitDebuggerDetected;
     }
 
     if (checkSuspiciousProcesses()) {
         std::cerr << kTag << "Suspicious process detected. Exiting.\n";
-        return 0xBAD; // code for bad process
+        return kExitSuspiciousProcess;
     }
 
-    if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
-        }
+    if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
+        std::cerr << kTag << "Integrity check failed (CRC32 mismatch). Exiting.\n";
+        return kExitIntegrityFailure;
     }
 
     std::cout << kTag << "All clear. Continue.\n";

--- a/AntiCheat.py
+++ b/AntiCheat.py
@@ -1,0 +1,57 @@
+"""Minimal Javelin anti-cheat guards for Python scripts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+EXIT_INTEGRITY_FAILURE = 0x1A
+
+
+def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_sha256(value: str) -> str:
+    return value.strip().lower()
+
+
+def check_script_integrity(
+    script_path: Path | None = None,
+    expected_sha256: str | None = None,
+) -> bool:
+    expected = expected_sha256 if expected_sha256 is not None else os.getenv(EXPECTED_SHA256_ENV)
+    if not expected:
+        return True
+
+    path = (script_path or Path(__file__)).resolve()
+    current = sha256_file(path)
+    return current == normalize_sha256(expected)
+
+
+def run_integrity_guard(script_path: Path | None = None) -> None:
+    if check_script_integrity(script_path):
+        return
+
+    print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+    raise SystemExit(EXIT_INTEGRITY_FAILURE)
+
+
+def main() -> int:
+    print(f"{TAG}starting checks...")
+    run_integrity_guard(Path(__file__))
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # py-workedtask
+
+Minimal Javelin anti-cheat guards with optional self-integrity checks.
+
+## C++ executable integrity
+
+`AntiCheat.cpp` computes CRC32 over the running executable and compares it to
+the optional `JAVELIN_EXPECTED_CRC32` build-time constant. The guard is disabled
+when the constant is left at `0u`.
+
+Build with MSVC and an expected CRC32 value:
+
+```powershell
+cl /EHsc /std:c++17 /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+If the executable CRC32 does not match, the process exits before continuing.
+
+## Python script integrity
+
+`AntiCheat.py` computes SHA-256 over the Python script file and compares it to
+the `JAVELIN_EXPECTED_SHA256` environment variable. The guard is disabled when
+the environment variable is unset or empty.
+
+Set the expected SHA-256 value before launching the script:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = "expected_sha256_hex_digest"
+python AntiCheat.py
+```
+
+If the script SHA-256 does not match, the process exits with a guarded failure.
+
+## Tests
+
+Run the Python integrity tests with:
+
+```powershell
+python -m unittest test_integrity.py
+```

--- a/test_integrity.py
+++ b/test_integrity.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from AntiCheat import (
+    EXIT_INTEGRITY_FAILURE,
+    EXPECTED_SHA256_ENV,
+    check_script_integrity,
+    run_integrity_guard,
+)
+
+
+class IntegrityTests(unittest.TestCase):
+    def test_missing_expected_hash_disables_python_integrity_check(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as file:
+            script_path = Path(file.name)
+            file.write(b"print('untagged build')\n")
+
+        self.addCleanup(script_path.unlink)
+
+        with mock.patch.dict("os.environ", {EXPECTED_SHA256_ENV: ""}, clear=False):
+            self.assertTrue(check_script_integrity(script_path))
+
+    def test_matching_sha256_allows_python_script(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as file:
+            script_path = Path(file.name)
+            payload = b"print('release build')\n"
+            file.write(payload)
+
+        self.addCleanup(script_path.unlink)
+
+        expected_hash = hashlib.sha256(payload).hexdigest().upper()
+        self.assertTrue(check_script_integrity(script_path, expected_hash))
+
+    def test_non_matching_sha256_causes_guarded_exit(self) -> None:
+        with tempfile.NamedTemporaryFile(delete=False) as file:
+            script_path = Path(file.name)
+            file.write(b"print('tampered build')\n")
+
+        self.addCleanup(script_path.unlink)
+
+        with mock.patch.dict("os.environ", {EXPECTED_SHA256_ENV: "0" * 64}, clear=False):
+            with self.assertRaises(SystemExit) as error:
+                run_integrity_guard(script_path)
+
+        self.assertEqual(error.exception.code, EXIT_INTEGRITY_FAILURE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds optional integrity verification for both anti-cheat implementations.

## Changes

- Keeps the C++ executable CRC32 guard optional via `JAVELIN_EXPECTED_CRC32`
- Fixes the invalid `0xCRC` exit code so the C++ file compiles
- Adds a Python SHA-256 script integrity guard using `JAVELIN_EXPECTED_SHA256`
- Documents how to set both expected values
- Adds Python tests for disabled, matching, and mismatching integrity checks

## Tests

```powershell
python -m unittest test_integrity.py
python -m py_compile AntiCheat.py test_integrity.py
```

Fixes #4.
