### PR TITLE
Add SHA-256 self-integrity checks

### DIFF
--- a/AntiCheat.cpp
+++ b/AntiCheat.cpp
@@ -1,6 +1,6 @@
 // AntiCheat.cpp
 // Javelin Project - Minimal Anti-Cheat guards
-// Features: debugger detection, suspicious process scan, basic self-integrity (CRC32)
+// Features: debugger detection, suspicious process scan, file integrity (CRC32/SHA-256)
 
 #include <windows.h>
 #include <tlhelp32.h>
@@ -9,6 +9,9 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <array>
+#include <iomanip>
+#include <sstream>
 
 static const char* kTag = "[Javelin AntiCheat] ";
 
@@ -41,6 +44,94 @@ static uint32_t crc32(const std::vector<uint8_t>& data) {
         }
     }
     return ~crc;
+}
+
+static uint32_t rotr(uint32_t value, uint32_t bits) {
+    return (value >> bits) | (value << (32 - bits));
+}
+
+static std::string sha256(const std::vector<uint8_t>& data) {
+    static constexpr std::array<uint32_t, 64> k = {
+        0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+        0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+        0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+        0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+        0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+        0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+        0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+        0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+        0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+        0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+        0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
+        0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+        0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
+        0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+        0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+        0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u
+    };
+
+    uint64_t bitLen = static_cast<uint64_t>(data.size()) * 8u;
+    std::vector<uint8_t> msg = data;
+    msg.push_back(0x80u);
+    while ((msg.size() % 64) != 56) msg.push_back(0u);
+    for (int i = 7; i >= 0; --i) {
+        msg.push_back(static_cast<uint8_t>((bitLen >> (i * 8)) & 0xffu));
+    }
+
+    uint32_t h0 = 0x6a09e667u;
+    uint32_t h1 = 0xbb67ae85u;
+    uint32_t h2 = 0x3c6ef372u;
+    uint32_t h3 = 0xa54ff53au;
+    uint32_t h4 = 0x510e527fu;
+    uint32_t h5 = 0x9b05688cu;
+    uint32_t h6 = 0x1f83d9abu;
+    uint32_t h7 = 0x5be0cd19u;
+
+    for (size_t offset = 0; offset < msg.size(); offset += 64) {
+        uint32_t w[64]{};
+        for (int i = 0; i < 16; ++i) {
+            size_t j = offset + i * 4;
+            w[i] = (static_cast<uint32_t>(msg[j]) << 24) |
+                   (static_cast<uint32_t>(msg[j + 1]) << 16) |
+                   (static_cast<uint32_t>(msg[j + 2]) << 8) |
+                   static_cast<uint32_t>(msg[j + 3]);
+        }
+        for (int i = 16; i < 64; ++i) {
+            uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+            uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        uint32_t a = h0, b = h1, c = h2, d = h3;
+        uint32_t e = h4, f = h5, g = h6, h = h7;
+
+        for (int i = 0; i < 64; ++i) {
+            uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            uint32_t ch = (e & f) ^ (~e & g);
+            uint32_t temp1 = h + s1 + ch + k[i] + w[i];
+            uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+            uint32_t temp2 = s0 + maj;
+
+            h = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+
+        h0 += a; h1 += b; h2 += c; h3 += d;
+        h4 += e; h5 += f; h6 += g; h7 += h;
+    }
+
+    std::ostringstream out;
+    for (uint32_t h : {h0, h1, h2, h3, h4, h5, h6, h7}) {
+        out << std::hex << std::setfill('0') << std::setw(8) << h;
+    }
+    return out.str();
 }
 
 static bool readFile(const std::wstring& path, std::vector<uint8_t>& out) {
@@ -102,7 +193,7 @@ static bool checkSuspiciousProcesses() {
     return false;
 }
 
-static bool checkSelfIntegrity(uint32_t expectedCrc) {
+static bool checkSelfIntegrity(uint32_t expectedCrc, const std::string& expectedSha256) {
     wchar_t path[MAX_PATH]{};
     if (!GetModuleFileNameW(nullptr, path, MAX_PATH)) return false;
 
@@ -110,12 +201,18 @@ static bool checkSelfIntegrity(uint32_t expectedCrc) {
     if (!readFile(path, bytes)) return false;
 
     uint32_t current = crc32(bytes);
-    return current == expectedCrc;
+    if (expectedCrc != 0u && current != expectedCrc) return false;
+    if (!expectedSha256.empty() && sha256(bytes) != toLower(expectedSha256)) return false;
+    return true;
 }
 
 // --- Entry helper (embed a baseline CRC once you ship a build) ---
 #ifndef JAVELIN_EXPECTED_CRC32
 #define JAVELIN_EXPECTED_CRC32 0u  // Set this at build time (e.g., /DJAVELIN_EXPECTED_CRC32=0x12345678)
+#endif
+
+#ifndef JAVELIN_EXPECTED_SHA256
+#define JAVELIN_EXPECTED_SHA256 ""  // Set this at build time (e.g., /DJAVELIN_EXPECTED_SHA256=\"...\")
 #endif
 
 int main() {
@@ -131,10 +228,10 @@ int main() {
         return 0xBAD; // code for bad process
     }
 
-    if (JAVELIN_EXPECTED_CRC32 != 0u) {
-        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32)) {
-            std::cerr << kTag << "Integrity check failed (CRC mismatch). Exiting.\n";
-            return 0xCRC; // custom code (note: non-standard, may be truncated)
+    if (JAVELIN_EXPECTED_CRC32 != 0u || std::string(JAVELIN_EXPECTED_SHA256).length() > 0) {
+        if (!checkSelfIntegrity(JAVELIN_EXPECTED_CRC32, JAVELIN_EXPECTED_SHA256)) {
+            std::cerr << kTag << "Integrity check failed (hash mismatch). Exiting.\n";
+            return 0xC0DE; // custom code (note: may be truncated by callers)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # py-workedtask
+
+Minimal Windows anti-cheat guard with:
+
+- debugger detection
+- suspicious process detection
+- CRC32 self-integrity checks
+- SHA-256 self-integrity checks
+
+## Build-time integrity configuration
+
+The integrity checker reads the running executable with `GetModuleFileNameW`
+and compares it against the expected hashes compiled into the binary.
+
+CRC32 can be enabled with:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+SHA-256 can be enabled with:
+
+```powershell
+cl /EHsc /DJAVELIN_EXPECTED_SHA256=\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" AntiCheat.cpp
+```
+
+Both checks can be enabled together. Leaving both values empty or zero keeps the
+integrity check disabled, which is useful while producing the first release
+build before calculating its final hashes.


### PR DESCRIPTION
/claim #4

Summary:
- Add SHA-256 self-integrity verification alongside the existing CRC32 check.
- Allow builds to enable CRC32, SHA-256, or both through JAVELIN_EXPECTED_CRC32 and JAVELIN_EXPECTED_SHA256.
- Document the build-time integrity flags in the README.

Testing:
- Not run locally: this source depends on Windows SDK headers (windows.h), and the current environment is macOS without the Windows build toolchain.

Closes #4