### PR TITLE
Add Python SHA-256 integrity verification

### DIFF
--- a/AntiCheat.py
+++ b/AntiCheat.py
@@ -1,0 +1,47 @@
+"""Minimal Python anti-cheat guards for py-workedtask.
+
+Optional integrity verification compares this script file's SHA-256 hash against
+JAVELIN_EXPECTED_SHA256. Leave the environment variable unset to disable the
+check during development.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+TAG = "[Javelin AntiCheat] "
+EXPECTED_SHA256_ENV = "JAVELIN_EXPECTED_SHA256"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def check_script_integrity(script_path: Path | None = None) -> bool:
+    expected = os.environ.get(EXPECTED_SHA256_ENV)
+    if not expected:
+        return True
+
+    target = script_path or Path(__file__).resolve()
+    current = sha256_file(target)
+    return current.lower() == expected.strip().lower()
+
+
+def main() -> int:
+    print(f"{TAG}starting Python checks...")
+    if not check_script_integrity():
+        print(f"{TAG}Integrity check failed (SHA-256 mismatch). Exiting.", file=sys.stderr)
+        return 0x51
+    print(f"{TAG}All clear. Continue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # py-workedtask
+
+Minimal anti-cheat guard examples for C++ and Python.
+
+## C++ integrity check
+
+`AntiCheat.cpp` computes CRC32 for the running executable when `JAVELIN_EXPECTED_CRC32` is set at build time. Leave it as `0` during development to disable the check.
+
+Example MSVC build with an expected CRC32:
+
+```bat
+cl /EHsc /DJAVELIN_EXPECTED_CRC32=0x12345678 AntiCheat.cpp
+```
+
+If the computed CRC does not match the build-time constant, the program exits through the guarded integrity failure path.
+
+## Python integrity check
+
+`AntiCheat.py` computes SHA-256 for the script file and compares it with the `JAVELIN_EXPECTED_SHA256` environment variable. Leave the variable unset during development to disable the check.
+
+Compute the current script hash:
+
+```bash
+python -c "from pathlib import Path; from AntiCheat import sha256_file; print(sha256_file(Path('AntiCheat.py')))"
+```
+
+Run with the expected hash:
+
+```bash
+export JAVELIN_EXPECTED_SHA256=<hash-from-command-above>
+python AntiCheat.py
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:JAVELIN_EXPECTED_SHA256 = '<hash-from-command-above>'
+python AntiCheat.py
+```
+
+If the hash does not match, the script exits through the guarded integrity failure path with a non-zero status.


### PR DESCRIPTION
Implements #4.

Implements optional Python script integrity verification and documents both C++ and Python expected-value setup.

What changed:

- Added `AntiCheat.py` with SHA-256 verification of the script file.
- The Python guard compares against `JAVELIN_EXPECTED_SHA256` when the env var is set.
- Non-matching hash exits through a guarded failure path with a non-zero status.
- Updated `README.md` with C++ CRC32 build-time setup and Python SHA-256 env var setup.

Validation:

```text
python -B -m py_compile AntiCheat.py

# matching hash
JAVELIN_EXPECTED_SHA256=<computed-hash> python AntiCheat.py
exit: 0

# mismatching hash
JAVELIN_EXPECTED_SHA256=deadbeef python AntiCheat.py
exit: 81
```
