### PR TITLE
feat: add SHA-256 self-integrity verification for Python (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
 # py-workedtask
+
+Minimal anti-cheat guards for the Javelin project, provided in both C++
+(`AntiCheat.cpp`) and Python (`anti_cheat.py`).
+
+## Python anti-cheat (`anti_cheat.py`)
+
+Cross-platform (Linux/Windows), standard-library only. It runs three guards:
+
+1. **Debugger detection** — `sys.gettrace`, `/proc/self/status` `TracerPid`
+   (Linux), `IsDebuggerPresent` (Windows).
+2. **Suspicious process scan** — known cheat/reversing tools.
+3. **Self-integrity verification (SHA-256)** — see below.
+
+### Self-integrity verification (SHA-256)
+
+`anti_cheat.py` computes the **SHA-256 of its own script file** and compares it
+to the value in the `JAVELIN_EXPECTED_SHA256` environment variable. If the
+hashes do not match, the program performs a **guarded exit** (exit code
+`0x0C8C`, surfaced as `0x8C`/140 on POSIX) instead of continuing to run
+possibly-tampered code. If the variable is unset or empty, the integrity check
+is skipped (it is optional, matching the build-time constant on the C++ side).
+
+#### How to set the expected value
+
+1. Compute the SHA-256 of the trusted, unmodified script:
+
+   ```bash
+   # Linux / macOS
+   sha256sum anti_cheat.py
+   # or, portably:
+   python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" anti_cheat.py
+   ```
+
+   ```powershell
+   # Windows (PowerShell)
+   (Get-FileHash -Algorithm SHA256 .\anti_cheat.py).Hash.ToLower()
+   ```
+
+2. Export it as the expected hash, then run:
+
+   ```bash
+   export JAVELIN_EXPECTED_SHA256="<hash-from-step-1>"
+   python3 anti_cheat.py
+   ```
+
+   ```powershell
+   $env:JAVELIN_EXPECTED_SHA256 = "<hash-from-step-1>"
+   python .\anti_cheat.py
+   ```
+
+If the script is modified after the hash is recorded, the check fails and the
+program exits without continuing.
+
+### Exit codes
+
+| Code      | Meaning                              |
+|-----------|--------------------------------------|
+| `0`       | All checks passed / not configured   |
+| `0xDEB`   | Debugger detected                    |
+| `0xBAD`   | Suspicious process detected          |
+| `0x0C8C`  | Integrity check failed (SHA-256)     |
+
+## Tests
+
+```bash
+python3 -m pytest test_anti_cheat.py -v
+# or, without pytest installed:
+python3 test_anti_cheat.py
+```
+
+## C++ anti-cheat (`AntiCheat.cpp`)
+
+The native implementation provides the same guards and supports an optional
+CRC32 build-time integrity constant (`JAVELIN_EXPECTED_CRC32`).

--- a/anti_cheat.py
+++ b/anti_cheat.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Javelin Project - Minimal Anti-Cheat guards (Python implementation).
+
+Mirrors the behaviour of ``AntiCheat.cpp`` for environments that run the
+Python tooling instead of the native C++ build.
+
+Features
+--------
+* Debugger detection (best-effort, cross-platform).
+* Suspicious process scan (cheat / debugging tooling).
+* Self-integrity verification using **SHA-256** of the running script file,
+  compared against the ``JAVELIN_EXPECTED_SHA256`` environment variable.
+
+The self-integrity check is the security primitive requested in issue #4:
+if the on-disk script has been tampered with, the computed SHA-256 will not
+match the expected value and the program performs a *guarded exit* instead of
+continuing to run untrusted code.
+
+Exit codes
+----------
+``0``       All checks passed (or integrity check not configured).
+``0xDEB``   Debugger detected.
+``0xBAD``   Suspicious process detected.
+``0x0C8C``  Integrity check failed (SHA-256 mismatch).
+
+The integrity-failure code ``0x0C8C`` is chosen so it fits in a single byte
+range on POSIX (``0x0C8C & 0xFF == 0x8C``) while remaining a recognisable
+constant in logs; the full value is also written to stderr.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from typing import Iterable, Optional
+
+TAG = "[Javelin AntiCheat] "
+
+# Exit codes (kept parallel to AntiCheat.cpp where practical).
+EXIT_OK = 0
+EXIT_DEBUGGER = 0xDEB
+EXIT_BAD_PROCESS = 0xBAD
+EXIT_INTEGRITY = 0x0C8C
+
+# Environment variable that holds the expected SHA-256 of this script file.
+ENV_EXPECTED_SHA256 = "JAVELIN_EXPECTED_SHA256"
+
+# Tooling commonly used for cheating / reversing. Matched case-insensitively
+# against process executable names. Mirrors kSuspiciousProcesses in the C++ side.
+SUSPICIOUS_PROCESSES = (
+    "cheatengine.exe",
+    "ollydbg.exe",
+    "x64dbg.exe",
+    "httpdebuggerui.exe",
+    "ida.exe",
+    "ida64.exe",
+    "scylla.exe",
+    "processhacker.exe",
+    # POSIX-friendly additions:
+    "cheatengine",
+    "ollydbg",
+    "x64dbg",
+    "ida",
+    "ida64",
+)
+
+# Read in 64 KiB chunks so large scripts never load fully into memory.
+_HASH_CHUNK = 64 * 1024
+
+
+# --------------------------------------------------------------------------- #
+# Self-integrity (SHA-256) — the core feature for issue #4.
+# --------------------------------------------------------------------------- #
+def compute_sha256(path: str) -> Optional[str]:
+    """Return the lowercase hex SHA-256 of *path*, or ``None`` if unreadable."""
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(_HASH_CHUNK), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _script_path() -> str:
+    """Absolute path to the running script file (resolves symlinks)."""
+    # ``sys.argv[0]`` reflects the invoked file; fall back to this module's file.
+    candidate = sys.argv[0] or __file__
+    if not os.path.isfile(candidate):
+        candidate = __file__
+    return os.path.realpath(candidate)
+
+
+def check_self_integrity(
+    expected: Optional[str] = None,
+    script_path: Optional[str] = None,
+) -> bool:
+    """Verify the on-disk script matches the expected SHA-256.
+
+    Parameters
+    ----------
+    expected:
+        Expected lowercase hex SHA-256. If ``None`` it is read from the
+        ``JAVELIN_EXPECTED_SHA256`` environment variable.
+    script_path:
+        Path to hash. Defaults to the running script file.
+
+    Returns
+    -------
+    bool
+        ``True`` when the hash matches (or no expected value is configured —
+        the check is *optional* by design, like the C++ build-time constant).
+        ``False`` only when an expected value is configured **and** the
+        computed hash differs (or the file cannot be read).
+    """
+    if expected is None:
+        expected = os.environ.get(ENV_EXPECTED_SHA256, "").strip()
+
+    # Not configured -> check is a no-op (optional integrity, matches C++).
+    if not expected:
+        return True
+
+    expected = expected.lower()
+    actual = compute_sha256(script_path or _script_path())
+    if actual is None:
+        return False
+    return actual == expected
+
+
+# --------------------------------------------------------------------------- #
+# Debugger detection (best-effort, cross-platform).
+# --------------------------------------------------------------------------- #
+def check_debugger() -> bool:
+    """Return ``True`` if a debugger appears to be attached."""
+    # Active Python tracer (pdb / IDE debugger) hooked into the interpreter.
+    if sys.gettrace() is not None:
+        return True
+
+    # Windows: IsDebuggerPresent via kernel32.
+    if sys.platform.startswith("win"):
+        try:
+            import ctypes
+
+            if ctypes.windll.kernel32.IsDebuggerPresent():  # type: ignore[attr-defined]
+                return True
+        except Exception:
+            pass
+        return False
+
+    # Linux: TracerPid in /proc/self/status is non-zero when traced (ptrace).
+    try:
+        with open("/proc/self/status", "r", encoding="ascii", errors="ignore") as status:
+            for line in status:
+                if line.startswith("TracerPid:"):
+                    return int(line.split(":", 1)[1].strip() or "0") != 0
+    except OSError:
+        pass
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Suspicious process scan.
+# --------------------------------------------------------------------------- #
+def _iter_process_names() -> Iterable[str]:
+    """Yield lowercase process executable names for the current platform."""
+    if sys.platform.startswith("win"):
+        try:
+            import subprocess
+
+            output = subprocess.run(
+                ["tasklist", "/fo", "csv", "/nh"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            ).stdout
+            for line in output.splitlines():
+                if line.startswith('"'):
+                    yield line.split('","', 1)[0].strip('"').lower()
+        except Exception:
+            return
+        return
+
+    # POSIX: read executable names from /proc.
+    proc = "/proc"
+    if not os.path.isdir(proc):
+        return
+    for pid in os.listdir(proc):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(os.path.join(proc, pid, "comm"), "r", encoding="ascii", errors="ignore") as f:
+                yield f.read().strip().lower()
+        except OSError:
+            continue
+
+
+def check_suspicious_processes() -> bool:
+    """Return ``True`` if a known cheating/debugging tool is running."""
+    bad = {name.lower() for name in SUSPICIOUS_PROCESSES}
+    for name in _iter_process_names():
+        # Match exact name or basename without extension.
+        if name in bad or os.path.splitext(name)[0] in bad:
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Entry point.
+# --------------------------------------------------------------------------- #
+def run_checks() -> int:
+    """Run all guards in order and return the appropriate exit code."""
+    print(f"{TAG}starting checks...")
+
+    if check_debugger():
+        print(f"{TAG}Debugger detected. Exiting.", file=sys.stderr)
+        return EXIT_DEBUGGER
+
+    if check_suspicious_processes():
+        print(f"{TAG}Suspicious process detected. Exiting.", file=sys.stderr)
+        return EXIT_BAD_PROCESS
+
+    if not check_self_integrity():
+        print(
+            f"{TAG}Integrity check failed (SHA-256 mismatch). "
+            f"Exiting with code {EXIT_INTEGRITY:#06x}.",
+            file=sys.stderr,
+        )
+        return EXIT_INTEGRITY
+
+    print(f"{TAG}All clear. Continue.")
+    return EXIT_OK
+
+
+def main() -> int:  # pragma: no cover - thin CLI wrapper
+    return run_checks()
+
+
+if __name__ == "__main__":
+    sys.exit(run_checks())

--- a/test_anti_cheat.py
+++ b/test_anti_cheat.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for the Javelin Python anti-cheat self-integrity feature (issue #4).
+
+Run with:  python3 -m pytest test_anti_cheat.py -v
+       or:  python3 test_anti_cheat.py   (built-in fallback runner)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+
+import anti_cheat
+
+
+def _write_temp_script(body: str = "print('hi')\n") -> str:
+    fd, path = tempfile.mkstemp(suffix=".py")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(body)
+    return path
+
+
+def test_compute_sha256_matches_hashlib():
+    path = _write_temp_script("data\n")
+    try:
+        expected = hashlib.sha256(b"data\n").hexdigest()
+        assert anti_cheat.compute_sha256(path) == expected
+    finally:
+        os.remove(path)
+
+
+def test_compute_sha256_unreadable_returns_none():
+    assert anti_cheat.compute_sha256("/no/such/file/at/all.py") is None
+
+
+def test_integrity_passes_on_match():
+    path = _write_temp_script("matched content\n")
+    try:
+        good = anti_cheat.compute_sha256(path)
+        assert anti_cheat.check_self_integrity(expected=good, script_path=path) is True
+    finally:
+        os.remove(path)
+
+
+def test_integrity_fails_on_mismatch():
+    path = _write_temp_script("real content\n")
+    try:
+        wrong = "0" * 64
+        assert anti_cheat.check_self_integrity(expected=wrong, script_path=path) is False
+    finally:
+        os.remove(path)
+
+
+def test_integrity_case_insensitive_expected():
+    path = _write_temp_script("case test\n")
+    try:
+        good = anti_cheat.compute_sha256(path).upper()  # uppercase expected
+        assert anti_cheat.check_self_integrity(expected=good, script_path=path) is True
+    finally:
+        os.remove(path)
+
+
+def test_integrity_noop_when_unconfigured():
+    # Empty/absent expected value -> optional check is a no-op (returns True).
+    assert anti_cheat.check_self_integrity(expected="", script_path=__file__) is True
+
+
+def test_integrity_reads_env_var(monkeypatch=None):
+    path = _write_temp_script("env content\n")
+    try:
+        good = anti_cheat.compute_sha256(path)
+        os.environ[anti_cheat.ENV_EXPECTED_SHA256] = good
+        try:
+            assert anti_cheat.check_self_integrity(script_path=path) is True
+            os.environ[anti_cheat.ENV_EXPECTED_SHA256] = "deadbeef"
+            assert anti_cheat.check_self_integrity(script_path=path) is False
+        finally:
+            os.environ.pop(anti_cheat.ENV_EXPECTED_SHA256, None)
+    finally:
+        os.remove(path)
+
+
+def test_end_to_end_guarded_exit_on_tamper():
+    """Run the script as a subprocess with a wrong expected hash -> exit 0x0C8C."""
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "anti_cheat.py")
+    env = dict(os.environ)
+    env[anti_cheat.ENV_EXPECTED_SHA256] = "0" * 64  # deliberately wrong
+    env.pop("PYTHONBREAKPOINT", None)
+    result = subprocess.run(
+        [sys.executable, script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    # 0x0C8C truncates to 0x8C (140) as a POSIX exit status.
+    assert result.returncode == (anti_cheat.EXIT_INTEGRITY & 0xFF)
+    assert "Integrity check failed" in result.stderr
+
+
+def test_end_to_end_pass_with_correct_hash():
+    script = os.path.join(os.path.dirname(os.path.abspath(__file__)), "anti_cheat.py")
+    good = anti_cheat.compute_sha256(script)
+    env = dict(os.environ)
+    env[anti_cheat.ENV_EXPECTED_SHA256] = good
+    env.pop("PYTHONBREAKPOINT", None)
+    result = subprocess.run(
+        [sys.executable, script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    # No tampering, no debugger/suspicious process expected in CI -> clean exit.
+    assert result.returncode == anti_cheat.EXIT_OK
+    assert "All clear" in result.stdout
+
+
+if __name__ == "__main__":
+    # Minimal fallback runner when pytest is unavailable.
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"ERROR {name}: {exc!r}")
+    print(f"\n{'ALL TESTS PASSED' if failures == 0 else f'{failures} FAILURE(S)'}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
/claim #4

## Summary
Implements the integrity verification requested in #4 for the Python implementation.

`anti_cheat.py` computes the SHA-256 of its own running script file and compares it against the `JAVELIN_EXPECTED_SHA256` environment variable. On mismatch it performs a guarded exit (code 0x0C8C) instead of running tampered code. When the variable is unset, the check is a safe no-op (optional, mirroring the C++ build-time constant).

## Acceptance criteria
- [x] AC1 - Tampered script (hash mismatch) triggers guarded exit with a clear stderr message; correct hash continues cleanly. Verified by end-to-end subprocess tests.
- [x] AC2 - README documents how to compute (sha256sum / Get-FileHash / portable Python one-liner) and set JAVELIN_EXPECTED_SHA256.
- [x] Mirrors existing C++ guards, stdlib-only, cross-platform.

## Tests
9 tests passing under both pytest and the stdlib fallback runner.

## Files
- anti_cheat.py (new)
- test_anti_cheat.py (new)
- README.md (updated)
- .gitignore (new)

Closes #4

---
Bounty payout wallet (ETH): 0x911d202f713Ee2ad139E8b8b8a0A712347eFE31f